### PR TITLE
Update base url

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = "https://vigotech.github.io"
+baseURL = "https://vigotech.org"
 languageCode = "gl-es"
 title = "Vigo Tech Alliance"
 publishDir = "docs"


### PR DESCRIPTION
PR para cerrar la issue #20 

En el baseURL estaba la configuración legacy de Github. Ahora mismo el certificado ya está activo en https://vigotech.org pero está dando un error al intentar cargar contenidos por http. Supongo que como no está forzado Github está haciendo un redirección. Una vez se suba a producción forzamos https en Github.