### PR TITLE
Correxida conta de Twitter de PythonVigo

### DIFF
--- a/static/vigotech.json
+++ b/static/vigotech.json
@@ -164,7 +164,7 @@
       "logo": "https://vigotech.org/images/python_vigo.png",
       "links": {
         "web": "https://www.python-vigo.es/",
-        "twitter": "https://twitter.com/python_vigo?lang=es",
+        "twitter": "https://twitter.com/python_vigo",
         "maillist": "https://lists.es.python.org/listinfo/vigo",
         "youtube": "https://www.youtube.com/channel/UCTUXabChakosnupWEnz4xTA"
       },


### PR DESCRIPTION
Correxida a conta de Twitter de PythonVigo para que apareza correctamente nos diferentes sistemas de notificación.

![Imaxe](https://user-images.githubusercontent.com/3040555/57855471-0ff14200-77eb-11e9-8a38-8cfac9b57b37.png)
