### PR TITLE
Update google calendar key

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ $ yarn install
 
 # rename .env.example to .env and edit using your own config
 
-# prepare date to generate website
-$ yarn prepare
+# prepare required static/vigotech-generated.json
+$ yarn run prepare-json
 
 # serve with hot reload at localhost:3000
 $ yarn run dev

--- a/static/gcalendar/gcal.html
+++ b/static/gcalendar/gcal.html
@@ -25,7 +25,7 @@
 
         displayEventTime: false, // don't show the time column in list view
 
-        googleCalendarApiKey: 'AIzaSyD0RDcErlth3OiJPyunH3dovUDK1KTh4rA',
+        googleCalendarApiKey: 'AIzaSyDErCM9R4qfnovHyfCy37uVil24BNddRHQ',
 
         events: 'orestes.io_fj8ev1vakdnl8l8o6jeljhof1s@group.calendar.google.com',
 


### PR DESCRIPTION
Engadida unha nova api key xa que a antiga non funcionaba, tamen actualizado o README do comando `prepare` que penso se quedou obsoleto.