### PR TITLE
Eliminar a ligazón á web de Agile Vigo

### DIFF
--- a/static/vigotech.json
+++ b/static/vigotech.json
@@ -17,7 +17,6 @@
       "name": "Agile Vigo",
       "logo": "https://vigotech.org/images/agile_vigo.jpg",
       "links": {
-        "web": "https://www.agilevigo.com/",
         "twitter": "https://twitter.com/agilevigo",
         "meetup": "https://www.meetup.com/es-ES/agile-vigo/",
         "github": "https://github.com/agileVigo"


### PR DESCRIPTION
Xa non dispoñemos de esta web nunca máis. 
De este modo non aparecerá na web da VigoTech.