### PR TITLE
Added Telegram, Mastodon and Matrix channels for GALPon.org

### DIFF
--- a/static/vigotech.json
+++ b/static/vigotech.json
@@ -79,6 +79,9 @@
       "logo": "https://vigotech.org/images/galpon.png",
       "links": {
         "web": "https://www.galpon.org",
+        "telegram": "https://t.me/galpon",
+        "mastodon": "https://mastodon.gal/@galpon",
+        "matrix": "https://matrix.to/#/#galpon:matrix",
         "twitter": "https://twitter.com/galpon",
         "maillist": "https://www.galpon.org/content/listas-correo-galpon"
       }


### PR DESCRIPTION
Not sure if "Matrix" Font Awesome icon exits. If not, this commit could break anything?