### PR TITLE
GitHub Actions fix for gh-pages.yml

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -2,7 +2,7 @@ name: GH-pages
 
 on:
   schedule:
-    - cron: "* 16 * * *"
+    - cron: "0 6,16 * * *"
   push:
     branches:
       - source
@@ -11,18 +11,18 @@ jobs:
   pages:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Use Node.js 12.x
-        uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@v4
         with:
-          node-version: '12.x'
+          node-version: '20.x'
       - name: Cache NPM dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: node_modules
-          key: ${{ runner.OS }}-npm-cache
+          key: ${{ runner.os }}-npm-cache
           restore-keys: |
-            ${{ runner.OS }}-npm-cache
+            ${{ runner.os }}-npm-cache
       - name: Install Dependencies
         run: yarn install
       - name: Prepare json


### PR DESCRIPTION
ci: update GitHub Actions and Node.js versions to fix deprecations, and fix cron

- Bump actions/cache from v2 to v4 to resolve critical deprecation error.
- Bump actions/checkout from v2 to v4 and actions/setup-node from v1 to v4.
- Upgrade Node.js from 12.x to 20.x (Node 12 is End-of-Life).
- Fix context property casing (runner.OS -> runner.os) to match official docs.
- Only launch at minute 0. Added 06:00 launch.

(Vibe coded with z.ai 😇)