### PR TITLE
feat: Add Galpon calendar temporary  url

### DIFF
--- a/static/vigotech.json
+++ b/static/vigotech.json
@@ -80,6 +80,10 @@
       "links": {
         "web": "https://www.galpon.org",
         "maillist": "https://www.galpon.org/content/listas-correo-galpon"
+      },
+      "events": {
+        "type": "json",
+        "source": "https://raw.githubusercontent.com/Daniel-at-github/vigotech_events/refs/heads/main/calendars/obradoiros_galpon.json"
       }
     },
     "galstech": {


### PR DESCRIPTION
As a temporary patch a repo fetching galpon activities (and others) was made. 
This change adds the galpon data to populate Vigotech calendar.