### PR TITLE
fix(ci): refresh Meetup events and upgrade actions

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -34,16 +34,16 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
+        with:
+          version: 10
+
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: pnpm
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v5
-        with:
-          version: 10
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -80,16 +80,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
+        with:
+          version: 10
+
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: pnpm
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v5
-        with:
-          version: 10
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary
This PR updates the site to consume `metagroup-schema-tools@1.1.1`, which restores missing Meetup-backed events by providing stable event source IDs.
It also upgrades the Pages workflow actions to current major versions and switches pnpm caching to the supported `setup-node` flow, including the required setup ordering fix.

## Changes
### Fixes
- Bump `metagroup-schema-tools` to `1.1.1` so Meetup events include stable `sourceId` values
- Regenerate event content and generated JSON so missing A Industriosa Meetup events are restored
- Normalize event and video `groupLogo` values through local asset paths in content parsing
- Fix the Pages workflow so pnpm is installed before `setup-node` initializes pnpm caching

### Chores
- Upgrade workflow actions to current major versions for checkout, setup-node, pnpm setup, Pages artifact upload, and Pages deploy
- Replace the manual pnpm store cache steps with `actions/setup-node` built-in pnpm caching

## PR Details (AI generated)

### Goals
This PR addresses two related maintenance issues on the website branch. First, it restores missing Meetup-backed events by consuming the new `metagroup-schema-tools@1.1.1` package output, which now provides stable source IDs for generated event history. Second, it modernizes the GitHub Pages deployment workflow by upgrading the Actions versions and aligning the pnpm caching setup with current action documentation.

### Changes in detail

#### Fixes
- Updated the website dependency to `metagroup-schema-tools@^1.1.1`
- Regenerated `public/vigotech-generated.json` and event content files to capture the corrected Meetup event identifiers
- Restored additional A Industriosa Meetup events and refreshed the relevant VigoWordPress event entry
- Kept the content-level logo normalization so event and video cards resolve local group logo assets correctly
- Fixed the workflow runtime error where `setup-node` attempted to enable pnpm caching before pnpm had been installed

#### Chores
- Upgraded `actions/checkout` to `v6`
- Upgraded `actions/setup-node` to `v6`
- Upgraded `pnpm/action-setup` to `v5`
- Upgraded `actions/upload-pages-artifact` to `v4`
- Upgraded `actions/deploy-pages` to `v5`
- Removed the explicit `actions/cache` pnpm store steps in favor of `setup-node` managed pnpm caching

### Notes
This PR includes generated content updates because the package fix changes event identity data used by the site generator. The workflow portion was kept minimal beyond the version upgrades and cache migration so that the deployment behavior remains the same apart from the documented pnpm setup ordering fix.