### PR TITLE
fix(site): restore logos and clean event data

### DIFF
--- a/public/vigotech-generated.json
+++ b/public/vigotech-generated.json
@@ -15,7 +15,7 @@
   "members": {
     "agilevigo": {
       "name": "Agile Vigo",
-      "logo": "https://vigotech.org/images/agile_vigo.jpg",
+      "logo": "https://vigotech.org/images/groups/agile_vigo.jpg",
       "links": {
         "twitter": "https://twitter.com/agilevigo",
         "meetup": "https://www.meetup.com/es-ES/agile-vigo/",
@@ -39,7 +39,7 @@
     },
     "aindustriosa": {
       "name": "A Industriosa",
-      "logo": "https://vigotech.org/images/aindustriosa.png",
+      "logo": "https://vigotech.org/images/groups/aindustriosa.png",
       "links": {
         "web": "https://aindustriosa.org/",
         "twitter": "https://twitter.com/aindustriosa",
@@ -1223,7 +1223,7 @@
     },
     "blockchaingal": {
       "name": "Blockchain.gal Vigo",
-      "logo": "https://vigotech.org/images/blockchaingal.png",
+      "logo": "https://vigotech.org/images/groups/blockchaingal.png",
       "links": {
         "web": "https://blockchain.gal/",
         "twitter": "https://twitter.com/blockchain_gal",
@@ -1239,9 +1239,23 @@
       "videoList": [],
       "eventList": []
     },
+    "cloudnativegalicia": {
+      "name": "Cloud Native Galicia",
+      "logo": "https://cloudnativegalicia.es/wp-content/uploads/2024/08/cncfgalicia4.jpg",
+      "links": {
+        "web": "https://cloudnativegalicia.es/",
+        "twitter": "https://x.com/cloudnativegal",
+        "linkedin": "https://www.linkedin.com/company/104357067",
+        "cncf": "https://community.cncf.io/cloud-native-galicia/"
+      },
+      "inactive": true,
+      "nextEvent": null,
+      "videoList": [],
+      "eventList": []
+    },
     "craftersvigo": {
       "name": "Crafters Vigo",
-      "logo": "https://vigotech.org/images/craftersVigo.png",
+      "logo": "https://vigotech.org/images/groups/craftersVigo.png",
       "links": {
         "twitter": "https://twitter.com/CraftersVigo",
         "meetup": "https://www.meetup.com/craftersvigo/"
@@ -1261,10 +1275,9 @@
     },
     "galpon": {
       "name": "GALPon",
-      "logo": "https://vigotech.org/images/galpon.png",
+      "logo": "https://vigotech.org/images/groups/galpon.png",
       "links": {
-        "web": "https://www.galpon.org",
-        "maillist": "https://www.galpon.org/content/listas-correo-galpon"
+        "web": "https://www.galpon.org"
       },
       "events": {
         "type": "json",
@@ -1276,7 +1289,7 @@
     },
     "galstech": {
       "name": "GalsTech",
-      "logo": "https://vigotech.org/images/galstech.png",
+      "logo": "https://vigotech.org/images/groups/galstech.png",
       "links": {
         "meetup": "https://www.meetup.com/GalsTech/",
         "twitter": "https://twitter.com/galstech_?lang=es"
@@ -1292,7 +1305,7 @@
     },
     "gdgvigo": {
       "name": "GDG Vigo",
-      "logo": "https://vigotech.org/images/gdg_vigo.png",
+      "logo": "https://vigotech.org/images/groups/gdg_vigo.png",
       "links": {
         "twitter": "http://twitter.com/GDGVigo/",
         "meetup": "https://www.meetup.com/es-ES/GDGVigo/?chapter_analytics_code=UA-73757047-1",
@@ -1387,11 +1400,9 @@
     },
     "joomlavigo": {
       "name": "Grupo de Usuarios de Joomla de Vigo",
-      "logo": "https://vigotech.org/images/joomla_vigo.png",
+      "logo": "https://vigotech.org/images/groups/joomla_vigo.png",
       "links": {
-        "web": "https://www.joomlavigo.es/",
-        "twitter": "https://twitter.com/JoomlaVigo",
-        "facebook": "https://www.facebook.com/JoomlaVigo/"
+        "web": "https://www.joomlavigo.es/"
       },
       "nextEvent": null,
       "videoList": [],
@@ -1399,7 +1410,7 @@
     },
     "phpvigo": {
       "name": "PHPVigo",
-      "logo": "https://vigotech.org/images/php_vigo.jpg",
+      "logo": "https://vigotech.org/images/groups/php_vigo.jpg",
       "links": {
         "web": "http://phpvigo.com/",
         "meetup": "https://www.meetup.com/es-ES/PHPVigo/",
@@ -2588,7 +2599,7 @@
     },
     "pythonvigo": {
       "name": "PythonVigo",
-      "logo": "https://vigotech.org/images/python_vigo.png",
+      "logo": "https://vigotech.org/images/groups/python_vigo.png",
       "links": {
         "web": "https://www.python-vigo.es/",
         "twitter": "https://twitter.com/python_vigo",
@@ -3696,7 +3707,7 @@
     },
     "seogalicia": {
       "name": "Seo Galicia",
-      "logo": "https://vigotech.org/images/seogalicia.png",
+      "logo": "https://vigotech.org/images/groups/seogalicia.png",
       "links": {
         "facebook": "https://www.facebook.com/SEOGaliciaMeetup",
         "meetup": "https://www.meetup.com/es/SEO-Galicia/",
@@ -3713,7 +3724,7 @@
     },
     "sysadmingalicia": {
       "name": "SysAdmin Galicia",
-      "logo": "https://vigotech.org/images/sysadmin_galicia.jpg",
+      "logo": "https://vigotech.org/images/groups/sysadmin_galicia.jpg",
       "links": {
         "meetup": "https://www.meetup.com/es-ES/Sysadmin-Galicia/",
         "twitter": "https://twitter.com/sysadmingalicia/"
@@ -3735,7 +3746,7 @@
     },
     "uxgalicia": {
       "name": "UX Galicia",
-      "logo": "https://vigotech.org/images/ux_gal.jpg",
+      "logo": "https://vigotech.org/images/groups/ux_gal.jpg",
       "links": {
         "web": "http://www.uxgalicia.com/",
         "meetup": "https://www.meetup.com/es-ES/Experiencia-de-Usuario-Meetup/",
@@ -3752,7 +3763,7 @@
     },
     "vigoadg": {
       "name": "Vigo Android Developer Group",
-      "logo": "https://vigotech.org/images/vigoadg.jpg",
+      "logo": "https://vigotech.org/images/groups/vigoadg.jpg",
       "links": {
         "twitter": "https://twitter.com/VigoADG",
         "meetup": "https://www.meetup.com/Vigo-Android-Developer-Group/"
@@ -3768,7 +3779,7 @@
     },
     "vigojug": {
       "name": "VigoJUG",
-      "logo": "https://vigotech.org/images/vigojug.jpg",
+      "logo": "https://vigotech.org/images/groups/vigojug.jpg",
       "links": {
         "web": "http://www.vigojug.org/",
         "github": "https://github.com/vigojug/",
@@ -4692,25 +4703,9 @@
       ],
       "eventList": []
     },
-    "wppontevedra": {
-      "name": "WordpressPontevedra",
-      "logo": "https://vigotech.org/images/wordpress-pontevedra.png",
-      "links": {
-        "meetup": "https://www.meetup.com/es-ES/Pontevedra-WordPress-Meetup/",
-        "twitter": "https://twitter.com/wppontevedra"
-      },
-      "events": {
-        "type": "meetup",
-        "meetupid": "Pontevedra-WordPress-Meetup"
-      },
-      "inactive": true,
-      "nextEvent": null,
-      "videoList": [],
-      "eventList": []
-    },
     "vigowordpress": {
       "name": "VigoWordpress",
-      "logo": "https://vigotech.org/images/vigowordpress.png",
+      "logo": "https://vigotech.org/images/groups/vigowordpress.png",
       "links": {
         "mail": "wpmeetupvigo@gmail.com",
         "meetup": "https://www.meetup.com/es-ES/Vigo-WordPress-Meetup/",
@@ -4727,7 +4722,6 @@
           "channel_id": "UCuipENHgKAhr1VgK59156Tw"
         }
       ],
-      "inactive": true,
       "nextEvent": {
         "sourceId": "Vigo-WordPress-Meetup-314167142",
         "title": "Marketing4eCommerce: Cómo crear unha comunidade masiva e internacional con WP",

--- a/public/vigotech.json
+++ b/public/vigotech.json
@@ -15,7 +15,7 @@
   "members": {
     "agilevigo": {
       "name": "Agile Vigo",
-      "logo": "https://vigotech.org/images/agile_vigo.jpg",
+      "logo": "https://vigotech.org/images/groups/agile_vigo.jpg",
       "links": {
         "twitter": "https://twitter.com/agilevigo",
         "meetup": "https://www.meetup.com/es-ES/agile-vigo/",
@@ -31,7 +31,7 @@
     },
     "aindustriosa": {
       "name": "A Industriosa",
-      "logo": "https://vigotech.org/images/aindustriosa.png",
+      "logo": "https://vigotech.org/images/groups/aindustriosa.png",
       "links": {
         "web": "https://aindustriosa.org/",
         "twitter": "https://twitter.com/aindustriosa",
@@ -51,7 +51,7 @@
     },
     "blockchaingal": {
       "name": "Blockchain.gal Vigo",
-      "logo": "https://vigotech.org/images/blockchaingal.png",
+      "logo": "https://vigotech.org/images/groups/blockchaingal.png",
       "links": {
         "web": "https://blockchain.gal/",
         "twitter": "https://twitter.com/blockchain_gal",
@@ -72,11 +72,12 @@
         "twitter": "https://x.com/cloudnativegal",
         "linkedin": "https://www.linkedin.com/company/104357067",
         "cncf": "https://community.cncf.io/cloud-native-galicia/"
-      }
+      },
+      "inactive": true
     },
     "craftersvigo": {
       "name": "Crafters Vigo",
-      "logo": "https://vigotech.org/images/craftersVigo.png",
+      "logo": "https://vigotech.org/images/groups/craftersVigo.png",
       "links": {
         "twitter": "https://twitter.com/CraftersVigo",
         "meetup": "https://www.meetup.com/craftersvigo/"
@@ -88,7 +89,7 @@
     },
     "galpon": {
       "name": "GALPon",
-      "logo": "https://vigotech.org/images/galpon.png",
+      "logo": "https://vigotech.org/images/groups/galpon.png",
       "links": {
         "web": "https://www.galpon.org"
       },
@@ -99,7 +100,7 @@
     },
     "galstech": {
       "name": "GalsTech",
-      "logo": "https://vigotech.org/images/galstech.png",
+      "logo": "https://vigotech.org/images/groups/galstech.png",
       "links": {
         "meetup": "https://www.meetup.com/GalsTech/",
         "twitter": "https://twitter.com/galstech_?lang=es"
@@ -112,7 +113,7 @@
     },
     "gdgvigo": {
       "name": "GDG Vigo",
-      "logo": "https://vigotech.org/images/gdg_vigo.png",
+      "logo": "https://vigotech.org/images/groups/gdg_vigo.png",
       "links": {
         "twitter": "http://twitter.com/GDGVigo/",
         "meetup": "https://www.meetup.com/es-ES/GDGVigo/?chapter_analytics_code=UA-73757047-1",
@@ -134,14 +135,14 @@
     },
     "joomlavigo": {
       "name": "Grupo de Usuarios de Joomla de Vigo",
-      "logo": "https://vigotech.org/images/joomla_vigo.png",
+      "logo": "https://vigotech.org/images/groups/joomla_vigo.png",
       "links": {
         "web": "https://www.joomlavigo.es/"
       }
     },
     "phpvigo": {
       "name": "PHPVigo",
-      "logo": "https://vigotech.org/images/php_vigo.jpg",
+      "logo": "https://vigotech.org/images/groups/php_vigo.jpg",
       "links": {
         "web": "http://phpvigo.com/",
         "meetup": "https://www.meetup.com/es-ES/PHPVigo/",
@@ -169,7 +170,7 @@
     },
     "pythonvigo": {
       "name": "PythonVigo",
-      "logo": "https://vigotech.org/images/python_vigo.png",
+      "logo": "https://vigotech.org/images/groups/python_vigo.png",
       "links": {
         "web": "https://www.python-vigo.es/",
         "twitter": "https://twitter.com/python_vigo",
@@ -189,7 +190,7 @@
     },
     "seogalicia": {
       "name": "Seo Galicia",
-      "logo": "https://vigotech.org/images/seogalicia.png",
+      "logo": "https://vigotech.org/images/groups/seogalicia.png",
       "links": {
         "facebook": "https://www.facebook.com/SEOGaliciaMeetup",
         "meetup": "https://www.meetup.com/es/SEO-Galicia/",
@@ -203,7 +204,7 @@
     },
     "sysadmingalicia": {
       "name": "SysAdmin Galicia",
-      "logo": "https://vigotech.org/images/sysadmin_galicia.jpg",
+      "logo": "https://vigotech.org/images/groups/sysadmin_galicia.jpg",
       "links": {
         "meetup": "https://www.meetup.com/es-ES/Sysadmin-Galicia/",
         "twitter": "https://twitter.com/sysadmingalicia/"
@@ -222,7 +223,7 @@
     },
     "uxgalicia": {
       "name": "UX Galicia",
-      "logo": "https://vigotech.org/images/ux_gal.jpg",
+      "logo": "https://vigotech.org/images/groups/ux_gal.jpg",
       "links": {
         "web": "http://www.uxgalicia.com/",
         "meetup": "https://www.meetup.com/es-ES/Experiencia-de-Usuario-Meetup/",
@@ -236,7 +237,7 @@
     },
     "vigoadg": {
       "name": "Vigo Android Developer Group",
-      "logo": "https://vigotech.org/images/vigoadg.jpg",
+      "logo": "https://vigotech.org/images/groups/vigoadg.jpg",
       "links": {
         "twitter": "https://twitter.com/VigoADG",
         "meetup": "https://www.meetup.com/Vigo-Android-Developer-Group/"
@@ -249,7 +250,7 @@
     },
     "vigojug": {
       "name": "VigoJUG",
-      "logo": "https://vigotech.org/images/vigojug.jpg",
+      "logo": "https://vigotech.org/images/groups/vigojug.jpg",
       "links": {
         "web": "http://www.vigojug.org/",
         "github": "https://github.com/vigojug/",
@@ -278,7 +279,7 @@
     },
     "vigowordpress": {
       "name": "VigoWordpress",
-      "logo": "https://vigotech.org/images/vigowordpress.png",
+      "logo": "https://vigotech.org/images/groups/vigowordpress.png",
       "links": {
         "mail": "wpmeetupvigo@gmail.com",
         "meetup": "https://www.meetup.com/es-ES/Vigo-WordPress-Meetup/",

--- a/public/vigotech.json
+++ b/public/vigotech.json
@@ -64,6 +64,16 @@
       },
       "inactive": true
     },
+    "cloudnativegalicia": {
+      "name": "Cloud Native Galicia",
+      "logo": "https://cloudnativegalicia.es/wp-content/uploads/2024/08/cncfgalicia4.jpg",
+      "links": {
+        "web": "https://cloudnativegalicia.es/",
+        "twitter": "https://x.com/cloudnativegal",
+        "linkedin": "https://www.linkedin.com/company/104357067",
+        "cncf": "https://community.cncf.io/cloud-native-galicia/"
+      }
+    },
     "craftersvigo": {
       "name": "Crafters Vigo",
       "logo": "https://vigotech.org/images/craftersVigo.png",
@@ -80,8 +90,7 @@
       "name": "GALPon",
       "logo": "https://vigotech.org/images/galpon.png",
       "links": {
-        "web": "https://www.galpon.org",
-        "maillist": "https://www.galpon.org/content/listas-correo-galpon"
+        "web": "https://www.galpon.org"
       },
       "events": {
         "type": "json",
@@ -127,9 +136,7 @@
       "name": "Grupo de Usuarios de Joomla de Vigo",
       "logo": "https://vigotech.org/images/joomla_vigo.png",
       "links": {
-        "web": "https://www.joomlavigo.es/",
-        "twitter": "https://twitter.com/JoomlaVigo",
-        "facebook": "https://www.facebook.com/JoomlaVigo/"
+        "web": "https://www.joomlavigo.es/"
       }
     },
     "phpvigo": {
@@ -269,19 +276,6 @@
       ],
       "inactive": true
     },
-    "wppontevedra": {
-      "name": "WordpressPontevedra",
-      "logo": "https://vigotech.org/images/wordpress-pontevedra.png",
-      "links": {
-        "meetup": "https://www.meetup.com/es-ES/Pontevedra-WordPress-Meetup/",
-        "twitter": "https://twitter.com/wppontevedra"
-      },
-      "events": {
-        "type": "meetup",
-        "meetupid": "Pontevedra-WordPress-Meetup"
-      },
-      "inactive": true
-    },
     "vigowordpress": {
       "name": "VigoWordpress",
       "logo": "https://vigotech.org/images/vigowordpress.png",
@@ -300,8 +294,7 @@
           "type": "youtube",
           "channel_id": "UCuipENHgKAhr1VgK59156Tw"
         }
-      ],
-      "inactive": true
+      ]
     }
   }
 }

--- a/scripts/generate-vigotech-json.mjs
+++ b/scripts/generate-vigotech-json.mjs
@@ -106,6 +106,28 @@ const slugify = (value) =>
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/(^-|-$)/g, '')
 
+const toLocalGroupLogo = (logo) => {
+  if (!logo) {
+    return null
+  }
+
+  if (logo.startsWith('/images/groups/')) {
+    return logo
+  }
+
+  const fromGroupsUrl = logo.match(/\/images\/groups\/([^/?#]+)$/i)?.[1]
+  if (fromGroupsUrl) {
+    return `/images/groups/${fromGroupsUrl}`
+  }
+
+  const fromUrl = logo.match(/\/images\/([^/?#]+)$/i)?.[1]
+  if (fromUrl) {
+    return `/images/groups/${fromUrl}`
+  }
+
+  return logo
+}
+
 const ensureDirectory = async (directoryPath) => {
   await mkdir(directoryPath, { recursive: true })
 }
@@ -179,7 +201,8 @@ const buildFrontmatterDocument = (data) => `---\n${formatFrontmatterValue(data)}
 const getGroupName = (groupId, member) =>
   typeof member?.name === 'string' && member.name.trim() ? member.name : groupId
 
-const getGroupLogo = (member) => (typeof member?.logo === 'string' ? member.logo : null)
+const getGroupLogo = (member) =>
+  typeof member?.logo === 'string' ? toLocalGroupLogo(member.logo) : null
 
 const toContentSlug = (value, fallback) => {
   const slug = slugify(value)

--- a/src/components/home/CalendarSection.astro
+++ b/src/components/home/CalendarSection.astro
@@ -110,11 +110,34 @@ const calendarApiUrl = withBase('/api/calendar.json')
     })
 
     const weekdayFormatter = new Intl.DateTimeFormat(locale, { weekday: 'short' })
+    const vigoTimezone = 'Europe/Madrid'
 
     const getDateKey = (date) => `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`
     const keyToDate = (key) => {
       const [year, month, day] = key.split('-').map(Number)
       return new Date(year, month, day)
+    }
+    const getTimezoneDateParts = (date, timeZone) => {
+      const parts = new Intl.DateTimeFormat('en-CA', {
+        timeZone,
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+      }).formatToParts(date)
+
+      return {
+        year: Number(parts.find((part) => part.type === 'year')?.value),
+        month: Number(parts.find((part) => part.type === 'month')?.value) - 1,
+        day: Number(parts.find((part) => part.type === 'day')?.value),
+      }
+    }
+    const getTimezoneDateKey = (date, timeZone) => {
+      const { year, month, day } = getTimezoneDateParts(date, timeZone)
+      return `${year}-${month}-${day}`
+    }
+    const getDayStamp = (key) => {
+      const [year, month, day] = key.split('-').map(Number)
+      return Date.UTC(year, month, day)
     }
 
     const getEventsByDay = (events) => {
@@ -197,6 +220,9 @@ const calendarApiUrl = withBase('/api/calendar.json')
 
       const eventsByDay = getEventsByDay(events)
       const eventDays = new Set(eventsByDay.keys())
+      const now = new Date()
+      const todayKey = getTimezoneDateKey(now, vigoTimezone)
+      const todayStamp = getDayStamp(todayKey)
 
       calendarGrid.innerHTML = ''
 
@@ -223,6 +249,8 @@ const calendarApiUrl = withBase('/api/calendar.json')
         if (inMonth) {
           const key = getDateKey(currentDate)
           const hasEvents = hasEventsOnDate(eventsByDay, key)
+          const isToday = key === todayKey
+          const isPastDate = getDayStamp(key) < todayStamp
           dayCell.textContent = String(currentDate.getDate())
           dayCell.classList.remove('text-[var(--ink-soft)]')
           dayCell.classList.add('text-[var(--ink)]')
@@ -240,13 +268,26 @@ const calendarApiUrl = withBase('/api/calendar.json')
           }
 
           if (eventDays.has(key)) {
-            dayCell.classList.add('bg-primary', 'font-semibold', 'text-white')
+            if (isPastDate) {
+              dayCell.classList.add('bg-primary-past', 'font-semibold', 'text-white')
+            } else {
+              dayCell.classList.add('bg-primary', 'font-semibold', 'text-white')
+            }
           } else {
             dayCell.classList.add('bg-[var(--bg-panel)]/65')
           }
 
           if (selectedDateKey === key) {
             dayCell.classList.add('ring-2', 'ring-primary/40', 'ring-offset-2', 'ring-offset-[var(--bg-elevated)]')
+          }
+
+          if (isToday) {
+            dayCell.classList.add(
+              'outline',
+              'outline-2',
+              'outline-[var(--accent)]',
+              'outline-offset-2',
+            )
           }
         } else {
           dayCell.textContent = ''

--- a/src/components/home/GroupsSection.astro
+++ b/src/components/home/GroupsSection.astro
@@ -13,11 +13,7 @@ const { groups } = Astro.props
 const t = groupsT[LANG]
 ---
 
-<section
-  id="grupos"
-  class="reveal py-20"
-  style="--reveal-delay: 60ms;"
->
+<section id="grupos" class="reveal py-20" style="--reveal-delay: 60ms;">
   <div class="vt-content-shell">
     <header class="mb-6 text-center">
       <h2 class="font-headline text-3xl tracking-tight sm:text-5xl">
@@ -26,13 +22,9 @@ const t = groupsT[LANG]
     </header>
 
     <div
-      class="grid gap-3 [grid-template-columns:repeat(auto-fit,minmax(180px,1fr))]"
+      class="grid gap-3 [grid-template-columns:repeat(auto-fit,minmax(260px,1fr))]"
     >
-      {
-        groups.map((group) => (
-          <GroupCard group={group} compact={true} />
-        ))
-      }
+      {groups.map((group) => <GroupCard group={group} compact={true} />)}
     </div>
   </div>
 </section>

--- a/src/components/ui/GroupLogo.astro
+++ b/src/components/ui/GroupLogo.astro
@@ -1,5 +1,6 @@
 ---
 import { withBase } from '../../lib/base-path'
+import { toLocalGroupLogo } from '../../lib/vigotech/source'
 
 type Props = {
   src: string | null
@@ -25,20 +26,19 @@ const initials = name
   .join('')
   .toUpperCase()
 
-const resolvedSrc = src ? withBase(src) : null
+const normalizedSrc = toLocalGroupLogo(src)
+const resolvedSrc = normalizedSrc ? withBase(normalizedSrc) : null
+const frameClass = `vt-squircle ${sizeClass} aspect-square shrink-0 overflow-hidden border border-[var(--line)] ${customClass}`
 ---
 
 {
   resolvedSrc ? (
-    <img
-      src={resolvedSrc}
-      alt={name}
-      loading="lazy"
-      class={`vt-squircle ${sizeClass} border border-[var(--line)] bg-white object-cover ${customClass}`}
-    />
+    <div class={`${frameClass} bg-white`}>
+      <img src={resolvedSrc} alt={name} loading="lazy" class="block size-full object-contain p-1" />
+    </div>
   ) : (
     <div
-      class={`vt-squircle ${sizeClass} flex items-center justify-center border border-[var(--line)] bg-[var(--bg-elevated)] ${fallbackClass} ${customClass}`}
+      class={`${frameClass} flex items-center justify-center bg-[var(--bg-elevated)] ${fallbackClass}`}
       aria-label={name}
     >
       {initials || 'VT'}

--- a/src/content/events/agilevigo/agilevigo-1774544400000-vibe-coding-luxembourg-build-a-real-app-in-60-minutes-with-ai.md
+++ b/src/content/events/agilevigo/agilevigo-1774544400000-vibe-coding-luxembourg-build-a-real-app-in-60-minutes-with-ai.md
@@ -2,7 +2,7 @@
 sourceId: 'agilevigo-1774544400000-vibe-coding-luxembourg-build-a-real-app-in-60-minutes-with-ai'
 groupId: 'agilevigo'
 groupName: 'Agile Vigo'
-groupLogo: 'https://vigotech.org/images/agile_vigo.jpg'
+groupLogo: '/images/groups/agile_vigo.jpg'
 title: 'Vibe Coding Luxembourg: Build a Real App in 60 Minutes with AI'
 description: null
 date: 1774544400000

--- a/src/content/events/aindustriosa/aindustriosa-1776499200000-introducion-ao-procesado-de-audio-con-stm32-e-i2s.md
+++ b/src/content/events/aindustriosa/aindustriosa-1776499200000-introducion-ao-procesado-de-audio-con-stm32-e-i2s.md
@@ -2,7 +2,7 @@
 sourceId: 'aindustriosa-1776499200000-introducion-ao-procesado-de-audio-con-stm32-e-i2s'
 groupId: 'aindustriosa'
 groupName: 'A Industriosa'
-groupLogo: 'https://vigotech.org/images/aindustriosa.png'
+groupLogo: '/images/groups/aindustriosa.png'
 title: 'Introdución ao procesado de audio con STM32 e I2S'
 description: 'O vindeiro **18 de abril en A Industriosa** teremos unha sesión práctica para achegarnos ao mundo do procesado de audio dixital con microcontroladores **ST'
 date: 1776499200000

--- a/src/content/events/aindustriosa/aindustriosa-1776965400000-pensaches-algunha-vez-en-crear-unha-biblioteca-de-componentes-ui.md
+++ b/src/content/events/aindustriosa/aindustriosa-1776965400000-pensaches-algunha-vez-en-crear-unha-biblioteca-de-componentes-ui.md
@@ -2,7 +2,7 @@
 sourceId: 'aindustriosa-1776965400000-pensaches-algunha-vez-en-crear-unha-biblioteca-de-componentes-ui'
 groupId: 'aindustriosa'
 groupName: 'A Industriosa'
-groupLogo: 'https://vigotech.org/images/aindustriosa.png'
+groupLogo: '/images/groups/aindustriosa.png'
 title: 'Pensaches algunha vez en crear unha biblioteca de compoñentes UI?'
 description: "Queres saber todo o que necesitas para facelo?\nO vindeiro **18 de abril ás 19:30 en A Industriosa**, **Sergio Carracedo** explicará dende o principio:\n\n* *"
 date: 1776965400000

--- a/src/content/events/aindustriosa/aindustriosa-1777109400000-ciberseguridade-orientada-ao-ambito-domestico.md
+++ b/src/content/events/aindustriosa/aindustriosa-1777109400000-ciberseguridade-orientada-ao-ambito-domestico.md
@@ -2,7 +2,7 @@
 sourceId: 'aindustriosa-1777109400000-ciberseguridade-orientada-ao-ambito-domestico'
 groupId: 'aindustriosa'
 groupName: 'A Industriosa'
-groupLogo: 'https://vigotech.org/images/aindustriosa.png'
+groupLogo: '/images/groups/aindustriosa.png'
 title: 'Ciberseguridade orientada ao ámbito doméstico'
 description: 'Nesta charla abordaremos cuestións clave para mellorar a seguridade dixital no día a día da casa. Falaremos da xestión segura de contrasinais e dos distint'
 date: 1777109400000

--- a/src/content/events/craftersvigo/craftersvigo-1775583000000-65-forjando-codigo-tdd-con-ia-en-el-reino-medieval.md
+++ b/src/content/events/craftersvigo/craftersvigo-1775583000000-65-forjando-codigo-tdd-con-ia-en-el-reino-medieval.md
@@ -2,7 +2,7 @@
 sourceId: 'craftersvigo-1775583000000-65-forjando-codigo-tdd-con-ia-en-el-reino-medieval'
 groupId: 'craftersvigo'
 groupName: 'Crafters Vigo'
-groupLogo: 'https://vigotech.org/images/craftersVigo.png'
+groupLogo: '/images/groups/craftersVigo.png'
 title: '#65 - Forjando código: TDD con IA en el reino medieval'
 description: null
 date: 1775583000000

--- a/src/content/events/pythonvigo/pythonvigo-1750356000000-reunion-junio-2025.md
+++ b/src/content/events/pythonvigo/pythonvigo-1750356000000-reunion-junio-2025.md
@@ -2,7 +2,7 @@
 sourceId: 'pythonvigo-1750356000000-reunion-junio-2025'
 groupId: 'pythonvigo'
 groupName: 'PythonVigo'
-groupLogo: 'https://vigotech.org/images/python_vigo.png'
+groupLogo: '/images/groups/python_vigo.png'
 title: 'Reunión junio 2025'
 description: null
 date: 1750356000000

--- a/src/content/events/vigowordpress/vigowordpress-1776963600000-marketing4ecommerce-como-crear-unha-comunidade-masiva-e-internacional-con-wp.md
+++ b/src/content/events/vigowordpress/vigowordpress-1776963600000-marketing4ecommerce-como-crear-unha-comunidade-masiva-e-internacional-con-wp.md
@@ -2,7 +2,7 @@
 sourceId: 'vigowordpress-1776963600000-marketing4ecommerce-como-crear-unha-comunidade-masiva-e-internacional-con-wp'
 groupId: 'vigowordpress'
 groupName: 'VigoWordpress'
-groupLogo: 'https://vigotech.org/images/vigowordpress.png'
+groupLogo: '/images/groups/vigowordpress.png'
 title: 'Marketing4eCommerce: Cómo crear unha comunidade masiva e internacional con WP'
 description: "Desde o equipo de WordPress Vigo convidámosvos a unha nova edición da nosa Meetup.\n\n**Marketing4eCommerce: Cómo crear unha comunidade masiva e internaciona"
 date: 1776963600000

--- a/src/content/videos/aindustriosa/33xt39a-cec.md
+++ b/src/content/videos/aindustriosa/33xt39a-cec.md
@@ -2,7 +2,7 @@
 sourceId: '33Xt39a_cEc'
 groupId: 'aindustriosa'
 groupName: 'A Industriosa'
-groupLogo: 'https://vigotech.org/images/aindustriosa.png'
+groupLogo: '/images/groups/aindustriosa.png'
 title: '20250322 - Galegos na FOSDEM - José María Casanova'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=33Xt39a_cEc'

--- a/src/content/videos/aindustriosa/37xmhgwkuae.md
+++ b/src/content/videos/aindustriosa/37xmhgwkuae.md
@@ -2,7 +2,7 @@
 sourceId: '37xmhGWKuAE'
 groupId: 'aindustriosa'
 groupName: 'A Industriosa'
-groupLogo: 'https://vigotech.org/images/aindustriosa.png'
+groupLogo: '/images/groups/aindustriosa.png'
 title: '23012019 - Un repaso a las competiciones de robots siguelíneas'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=37xmhGWKuAE'

--- a/src/content/videos/aindustriosa/50trtscnuis.md
+++ b/src/content/videos/aindustriosa/50trtscnuis.md
@@ -2,7 +2,7 @@
 sourceId: '50TrtscnUis'
 groupId: 'aindustriosa'
 groupName: 'A Industriosa'
-groupLogo: 'https://vigotech.org/images/aindustriosa.png'
+groupLogo: '/images/groups/aindustriosa.png'
 title: '20210227 - Ultracasa 3000'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=50TrtscnUis'

--- a/src/content/videos/aindustriosa/7mvk7obsv80.md
+++ b/src/content/videos/aindustriosa/7mvk7obsv80.md
@@ -2,7 +2,7 @@
 sourceId: '7mVK7obSv80'
 groupId: 'aindustriosa'
 groupName: 'A Industriosa'
-groupLogo: 'https://vigotech.org/images/aindustriosa.png'
+groupLogo: '/images/groups/aindustriosa.png'
 title: 'A Industriosa - Promo'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=7mVK7obSv80'

--- a/src/content/videos/aindustriosa/7okgu70odti.md
+++ b/src/content/videos/aindustriosa/7okgu70odti.md
@@ -2,7 +2,7 @@
 sourceId: '7oKgu70oDtI'
 groupId: 'aindustriosa'
 groupName: 'A Industriosa'
-groupLogo: 'https://vigotech.org/images/aindustriosa.png'
+groupLogo: '/images/groups/aindustriosa.png'
 title: '20180601 - Garabullo - Diego Lale'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=7oKgu70oDtI'

--- a/src/content/videos/aindustriosa/9ga8hhu1dig.md
+++ b/src/content/videos/aindustriosa/9ga8hhu1dig.md
@@ -2,7 +2,7 @@
 sourceId: '9Ga8hHu1Dig'
 groupId: 'aindustriosa'
 groupName: 'A Industriosa'
-groupLogo: 'https://vigotech.org/images/aindustriosa.png'
+groupLogo: '/images/groups/aindustriosa.png'
 title: '20190304 - Charla ganadores Regata Solar 2018 categoría Open'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=9Ga8hHu1Dig'

--- a/src/content/videos/aindustriosa/9p2kho8rjw0.md
+++ b/src/content/videos/aindustriosa/9p2kho8rjw0.md
@@ -2,7 +2,7 @@
 sourceId: '9p2kho8RJW0'
 groupId: 'aindustriosa'
 groupName: 'A Industriosa'
-groupLogo: 'https://vigotech.org/images/aindustriosa.png'
+groupLogo: '/images/groups/aindustriosa.png'
 title: '20230414 - Rural Hackers'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=9p2kho8RJW0'

--- a/src/content/videos/aindustriosa/9u0djwikyga.md
+++ b/src/content/videos/aindustriosa/9u0djwikyga.md
@@ -2,7 +2,7 @@
 sourceId: '9U0djWiKyGA'
 groupId: 'aindustriosa'
 groupName: 'A Industriosa'
-groupLogo: 'https://vigotech.org/images/aindustriosa.png'
+groupLogo: '/images/groups/aindustriosa.png'
 title: '20250322 - Galegos na FOSDEM - David de la Iglesia'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=9U0djWiKyGA'

--- a/src/content/videos/aindustriosa/b6erbdjfbwg.md
+++ b/src/content/videos/aindustriosa/b6erbdjfbwg.md
@@ -2,7 +2,7 @@
 sourceId: 'b6ErBdjfBWg'
 groupId: 'aindustriosa'
 groupName: 'A Industriosa'
-groupLogo: 'https://vigotech.org/images/aindustriosa.png'
+groupLogo: '/images/groups/aindustriosa.png'
 title: '20190227 - Cómo construirte una impresora 3d XXL'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=b6ErBdjfBWg'

--- a/src/content/videos/aindustriosa/bmmg6o0i4ei.md
+++ b/src/content/videos/aindustriosa/bmmg6o0i4ei.md
@@ -2,7 +2,7 @@
 sourceId: 'bmMG6O0I4eI'
 groupId: 'aindustriosa'
 groupName: 'A Industriosa'
-groupLogo: 'https://vigotech.org/images/aindustriosa.png'
+groupLogo: '/images/groups/aindustriosa.png'
 title: '20200801 - [LIVE] - Hackeando mi robot aspirador'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=bmMG6O0I4eI'

--- a/src/content/videos/aindustriosa/br0vvthan6o.md
+++ b/src/content/videos/aindustriosa/br0vvthan6o.md
@@ -2,7 +2,7 @@
 sourceId: 'bR0vVThAn6o'
 groupId: 'aindustriosa'
 groupName: 'A Industriosa'
-groupLogo: 'https://vigotech.org/images/aindustriosa.png'
+groupLogo: '/images/groups/aindustriosa.png'
 title: 'A Industriosa no telexornal da TVG'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=bR0vVThAn6o'

--- a/src/content/videos/aindustriosa/crs2ofs-aqw.md
+++ b/src/content/videos/aindustriosa/crs2ofs-aqw.md
@@ -2,7 +2,7 @@
 sourceId: 'cRS2oFs_aqw'
 groupId: 'aindustriosa'
 groupName: 'A Industriosa'
-groupLogo: 'https://vigotech.org/images/aindustriosa.png'
+groupLogo: '/images/groups/aindustriosa.png'
 title: 'A Industriosa en Localia'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=cRS2oFs_aqw'

--- a/src/content/videos/aindustriosa/dntvdxvmlqy.md
+++ b/src/content/videos/aindustriosa/dntvdxvmlqy.md
@@ -2,7 +2,7 @@
 sourceId: 'DnTVDXVMLqY'
 groupId: 'aindustriosa'
 groupName: 'A Industriosa'
-groupLogo: 'https://vigotech.org/images/aindustriosa.png'
+groupLogo: '/images/groups/aindustriosa.png'
 title: '20250322 - Galegos na FOSDEM - Sam Thursfield'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=DnTVDXVMLqY'

--- a/src/content/videos/aindustriosa/e-3kozcmwbu.md
+++ b/src/content/videos/aindustriosa/e-3kozcmwbu.md
@@ -2,7 +2,7 @@
 sourceId: 'E-3KOZCmwBU'
 groupId: 'aindustriosa'
 groupName: 'A Industriosa'
-groupLogo: 'https://vigotech.org/images/aindustriosa.png'
+groupLogo: '/images/groups/aindustriosa.png'
 title: '20230511 -  Engineering Manager: Beyond Leadership'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=E-3KOZCmwBU'

--- a/src/content/videos/aindustriosa/e0sgibol7ek.md
+++ b/src/content/videos/aindustriosa/e0sgibol7ek.md
@@ -2,7 +2,7 @@
 sourceId: 'E0sGiBOL7ek'
 groupId: 'aindustriosa'
 groupName: 'A Industriosa'
-groupLogo: 'https://vigotech.org/images/aindustriosa.png'
+groupLogo: '/images/groups/aindustriosa.png'
 title: '20190304 - Charla Íñigo Echenique - Diseño Naval - TS Royalist'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=E0sGiBOL7ek'

--- a/src/content/videos/aindustriosa/eply147xqzw.md
+++ b/src/content/videos/aindustriosa/eply147xqzw.md
@@ -2,7 +2,7 @@
 sourceId: 'Eply147XQZw'
 groupId: 'aindustriosa'
 groupName: 'A Industriosa'
-groupLogo: 'https://vigotech.org/images/aindustriosa.png'
+groupLogo: '/images/groups/aindustriosa.png'
 title: '20180309 - Robótica de competición (Carreras, mini-sumo y humanoides) - OPROBOTS'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=Eply147XQZw'

--- a/src/content/videos/aindustriosa/fckzbnkm1hu.md
+++ b/src/content/videos/aindustriosa/fckzbnkm1hu.md
@@ -2,7 +2,7 @@
 sourceId: 'FckZbnkM1hU'
 groupId: 'aindustriosa'
 groupName: 'A Industriosa'
-groupLogo: 'https://vigotech.org/images/aindustriosa.png'
+groupLogo: '/images/groups/aindustriosa.png'
 title: 'Regata Solar - [LIVE] - Curso Electrónica e propulsión'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=FckZbnkM1hU'

--- a/src/content/videos/aindustriosa/fuq5glfzmja.md
+++ b/src/content/videos/aindustriosa/fuq5glfzmja.md
@@ -2,7 +2,7 @@
 sourceId: 'FuQ5glFzmJA'
 groupId: 'aindustriosa'
 groupName: 'A Industriosa'
-groupLogo: 'https://vigotech.org/images/aindustriosa.png'
+groupLogo: '/images/groups/aindustriosa.png'
 title: '20200408 - [LIVE] - Regata Solar - Curso Radiocontrol e Telemetría'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=FuQ5glFzmJA'

--- a/src/content/videos/aindustriosa/gtqkbhfsr-g.md
+++ b/src/content/videos/aindustriosa/gtqkbhfsr-g.md
@@ -2,7 +2,7 @@
 sourceId: 'GtqKbhFsR_g'
 groupId: 'aindustriosa'
 groupName: 'A Industriosa'
-groupLogo: 'https://vigotech.org/images/aindustriosa.png'
+groupLogo: '/images/groups/aindustriosa.png'
 title: '20200406 - Regata Solar - Curso Electrónica e propulsión'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=GtqKbhFsR_g'

--- a/src/content/videos/aindustriosa/jgk0obo0a7e.md
+++ b/src/content/videos/aindustriosa/jgk0obo0a7e.md
@@ -2,7 +2,7 @@
 sourceId: 'JgK0oBo0a7E'
 groupId: 'aindustriosa'
 groupName: 'A Industriosa'
-groupLogo: 'https://vigotech.org/images/aindustriosa.png'
+groupLogo: '/images/groups/aindustriosa.png'
 title: '20220709 - Autoconsumo Solar'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=JgK0oBo0a7E'

--- a/src/content/videos/aindustriosa/kx2p4b1cxck.md
+++ b/src/content/videos/aindustriosa/kx2p4b1cxck.md
@@ -2,7 +2,7 @@
 sourceId: 'Kx2P4b1cxCk'
 groupId: 'aindustriosa'
 groupName: 'A Industriosa'
-groupLogo: 'https://vigotech.org/images/aindustriosa.png'
+groupLogo: '/images/groups/aindustriosa.png'
 title: '20180301 - Monitorización de una regata de barcos radiocontrol'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=Kx2P4b1cxCk'

--- a/src/content/videos/aindustriosa/lo6yuysnamu.md
+++ b/src/content/videos/aindustriosa/lo6yuysnamu.md
@@ -2,7 +2,7 @@
 sourceId: 'lo6yuYSnAMU'
 groupId: 'aindustriosa'
 groupName: 'A Industriosa'
-groupLogo: 'https://vigotech.org/images/aindustriosa.png'
+groupLogo: '/images/groups/aindustriosa.png'
 title: '20190320 - Introducción a las FPGAs+Verilog'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=lo6yuYSnAMU'

--- a/src/content/videos/aindustriosa/m9beeq0osq8.md
+++ b/src/content/videos/aindustriosa/m9beeq0osq8.md
@@ -2,7 +2,7 @@
 sourceId: 'M9BeEq0OSq8'
 groupId: 'aindustriosa'
 groupName: 'A Industriosa'
-groupLogo: 'https://vigotech.org/images/aindustriosa.png'
+groupLogo: '/images/groups/aindustriosa.png'
 title: 'VigoTech na TVG'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=M9BeEq0OSq8'

--- a/src/content/videos/aindustriosa/nf8a-orqssi.md
+++ b/src/content/videos/aindustriosa/nf8a-orqssi.md
@@ -2,7 +2,7 @@
 sourceId: 'nf8a_OrQSSI'
 groupId: 'aindustriosa'
 groupName: 'A Industriosa'
-groupLogo: 'https://vigotech.org/images/aindustriosa.png'
+groupLogo: '/images/groups/aindustriosa.png'
 title: 'Badge OSHWDem 2017'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=nf8a_OrQSSI'

--- a/src/content/videos/aindustriosa/nkcyw4gnrmg.md
+++ b/src/content/videos/aindustriosa/nkcyw4gnrmg.md
@@ -2,7 +2,7 @@
 sourceId: 'nkcYW4GnRmg'
 groupId: 'aindustriosa'
 groupName: 'A Industriosa'
-groupLogo: 'https://vigotech.org/images/aindustriosa.png'
+groupLogo: '/images/groups/aindustriosa.png'
 title: '20220924 - Como (no) fabricar Motores Eléctricos'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=nkcYW4GnRmg'

--- a/src/content/videos/aindustriosa/nkeztnat9g4.md
+++ b/src/content/videos/aindustriosa/nkeztnat9g4.md
@@ -2,7 +2,7 @@
 sourceId: 'nkEzTnaT9g4'
 groupId: 'aindustriosa'
 groupName: 'A Industriosa'
-groupLogo: 'https://vigotech.org/images/aindustriosa.png'
+groupLogo: '/images/groups/aindustriosa.png'
 title: '20230626 - Robótica de competición: OPRobots, moita, moita proba e erro'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=nkEzTnaT9g4'

--- a/src/content/videos/aindustriosa/ojfntjlmroo.md
+++ b/src/content/videos/aindustriosa/ojfntjlmroo.md
@@ -2,7 +2,7 @@
 sourceId: 'OJFnTJlMrOo'
 groupId: 'aindustriosa'
 groupName: 'A Industriosa'
-groupLogo: 'https://vigotech.org/images/aindustriosa.png'
+groupLogo: '/images/groups/aindustriosa.png'
 title: 'Galicia, el espacio y por qué seguir explorando'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=OJFnTJlMrOo'

--- a/src/content/videos/aindustriosa/ozy-ptjtpxu.md
+++ b/src/content/videos/aindustriosa/ozy-ptjtpxu.md
@@ -2,7 +2,7 @@
 sourceId: 'Ozy-ptJtpXU'
 groupId: 'aindustriosa'
 groupName: 'A Industriosa'
-groupLogo: 'https://vigotech.org/images/aindustriosa.png'
+groupLogo: '/images/groups/aindustriosa.png'
 title: '20230624 - Tecnoloxía Aplicada á Investigación en Ocupación, Igualdade e Saúde'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=Ozy-ptJtpXU'

--- a/src/content/videos/aindustriosa/p4jz9ramhse.md
+++ b/src/content/videos/aindustriosa/p4jz9ramhse.md
@@ -2,7 +2,7 @@
 sourceId: 'P4Jz9ramhsE'
 groupId: 'aindustriosa'
 groupName: 'A Industriosa'
-groupLogo: 'https://vigotech.org/images/aindustriosa.png'
+groupLogo: '/images/groups/aindustriosa.png'
 title: 'Introducción a Mesa, por Igalia 28/10/2023'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=P4Jz9ramhsE'

--- a/src/content/videos/aindustriosa/pj5mekki06g.md
+++ b/src/content/videos/aindustriosa/pj5mekki06g.md
@@ -2,7 +2,7 @@
 sourceId: 'PJ5mEkki06g'
 groupId: 'aindustriosa'
 groupName: 'A Industriosa'
-groupLogo: 'https://vigotech.org/images/aindustriosa.png'
+groupLogo: '/images/groups/aindustriosa.png'
 title: '20240313 - Solana: unha guía para principiantes, por José Corral'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=PJ5mEkki06g'

--- a/src/content/videos/aindustriosa/r-k0saprzpw.md
+++ b/src/content/videos/aindustriosa/r-k0saprzpw.md
@@ -2,7 +2,7 @@
 sourceId: 'R_K0saprZPw'
 groupId: 'aindustriosa'
 groupName: 'A Industriosa'
-groupLogo: 'https://vigotech.org/images/aindustriosa.png'
+groupLogo: '/images/groups/aindustriosa.png'
 title: 'Reciclaxe de plásticos a pequeña escala con máquinas open source'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=R_K0saprZPw'

--- a/src/content/videos/aindustriosa/r1czgu-swsa.md
+++ b/src/content/videos/aindustriosa/r1czgu-swsa.md
@@ -2,7 +2,7 @@
 sourceId: 'R1CZGU-SWsA'
 groupId: 'aindustriosa'
 groupName: 'A Industriosa'
-groupLogo: 'https://vigotech.org/images/aindustriosa.png'
+groupLogo: '/images/groups/aindustriosa.png'
 title: '20180216 - Bulebule - Making of de un robot "micromouse"'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=R1CZGU-SWsA'

--- a/src/content/videos/aindustriosa/rezbm9lhdh4.md
+++ b/src/content/videos/aindustriosa/rezbm9lhdh4.md
@@ -2,7 +2,7 @@
 sourceId: 'ReZbM9lhdH4'
 groupId: 'aindustriosa'
 groupName: 'A Industriosa'
-groupLogo: 'https://vigotech.org/images/aindustriosa.png'
+groupLogo: '/images/groups/aindustriosa.png'
 title: '20180314 - Introducción al diseño naval - III Regata Solar - Íñigo Echenique'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=ReZbM9lhdH4'

--- a/src/content/videos/aindustriosa/rmtwdpjaheu.md
+++ b/src/content/videos/aindustriosa/rmtwdpjaheu.md
@@ -2,7 +2,7 @@
 sourceId: 'RMtWdPJaHeU'
 groupId: 'aindustriosa'
 groupName: 'A Industriosa'
-groupLogo: 'https://vigotech.org/images/aindustriosa.png'
+groupLogo: '/images/groups/aindustriosa.png'
 title: '20250322 - Galegos na FOSDEM - Xabier Crespo'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=RMtWdPJaHeU'

--- a/src/content/videos/aindustriosa/stf14pwimp4.md
+++ b/src/content/videos/aindustriosa/stf14pwimp4.md
@@ -2,7 +2,7 @@
 sourceId: 'STF14PwIMP4'
 groupId: 'aindustriosa'
 groupName: 'A Industriosa'
-groupLogo: 'https://vigotech.org/images/aindustriosa.png'
+groupLogo: '/images/groups/aindustriosa.png'
 title: 'CES UVigo: Fabricación de barcos solares tripulados para competición'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=STF14PwIMP4'

--- a/src/content/videos/aindustriosa/tnmsrnwnpyw.md
+++ b/src/content/videos/aindustriosa/tnmsrnwnpyw.md
@@ -2,7 +2,7 @@
 sourceId: 'tNMsRnwnpYw'
 groupId: 'aindustriosa'
 groupName: 'A Industriosa'
-groupLogo: 'https://vigotech.org/images/aindustriosa.png'
+groupLogo: '/images/groups/aindustriosa.png'
 title: '20200424 - [LIVE] - Open Research Rocketry'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=tNMsRnwnpYw'

--- a/src/content/videos/aindustriosa/up-hukomzco.md
+++ b/src/content/videos/aindustriosa/up-hukomzco.md
@@ -2,7 +2,7 @@
 sourceId: 'UP_HuKoMZco'
 groupId: 'aindustriosa'
 groupName: 'A Industriosa'
-groupLogo: 'https://vigotech.org/images/aindustriosa.png'
+groupLogo: '/images/groups/aindustriosa.png'
 title: '20181213 - E-téxtiles nos espacios maker'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=UP_HuKoMZco'

--- a/src/content/videos/aindustriosa/vrgi0hr0dsk.md
+++ b/src/content/videos/aindustriosa/vrgi0hr0dsk.md
@@ -2,7 +2,7 @@
 sourceId: 'Vrgi0hr0Dsk'
 groupId: 'aindustriosa'
 groupName: 'A Industriosa'
-groupLogo: 'https://vigotech.org/images/aindustriosa.png'
+groupLogo: '/images/groups/aindustriosa.png'
 title: '20190325 - Consecuencias de la Nueva Directiva de Copyright Europea (y qué puedo hacer)'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=Vrgi0hr0Dsk'

--- a/src/content/videos/aindustriosa/vyni1x3qgi0.md
+++ b/src/content/videos/aindustriosa/vyni1x3qgi0.md
@@ -2,7 +2,7 @@
 sourceId: 'VynI1x3QGI0'
 groupId: 'aindustriosa'
 groupName: 'A Industriosa'
-groupLogo: 'https://vigotech.org/images/aindustriosa.png'
+groupLogo: '/images/groups/aindustriosa.png'
 title: '20200319 - [LIVE] - Introducción a Lora e LoraWAN'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=VynI1x3QGI0'

--- a/src/content/videos/aindustriosa/w3binwrun88.md
+++ b/src/content/videos/aindustriosa/w3binwrun88.md
@@ -2,7 +2,7 @@
 sourceId: 'w3BInWruN88'
 groupId: 'aindustriosa'
 groupName: 'A Industriosa'
-groupLogo: 'https://vigotech.org/images/aindustriosa.png'
+groupLogo: '/images/groups/aindustriosa.png'
 title: 'Time-lapse da montaxe Scanner 3D Ciclop'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=w3BInWruN88'

--- a/src/content/videos/aindustriosa/w40f9woatq4.md
+++ b/src/content/videos/aindustriosa/w40f9woatq4.md
@@ -2,7 +2,7 @@
 sourceId: 'w40F9WOatq4'
 groupId: 'aindustriosa'
 groupName: 'A Industriosa'
-groupLogo: 'https://vigotech.org/images/aindustriosa.png'
+groupLogo: '/images/groups/aindustriosa.png'
 title: '20240613 - Descobre o poder da programación funcional a través de OCaml, por Jose Castillo'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=w40F9WOatq4'

--- a/src/content/videos/aindustriosa/ygde-hwi2-m.md
+++ b/src/content/videos/aindustriosa/ygde-hwi2-m.md
@@ -2,7 +2,7 @@
 sourceId: 'ygDE-hWi2-M'
 groupId: 'aindustriosa'
 groupName: 'A Industriosa'
-groupLogo: 'https://vigotech.org/images/aindustriosa.png'
+groupLogo: '/images/groups/aindustriosa.png'
 title: '20180123 - TVG - Entrevista a Ana Cidre'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=ygDE-hWi2-M'

--- a/src/content/videos/aindustriosa/z1q7z6whz8a.md
+++ b/src/content/videos/aindustriosa/z1q7z6whz8a.md
@@ -2,7 +2,7 @@
 sourceId: 'Z1Q7z6Whz8A'
 groupId: 'aindustriosa'
 groupName: 'A Industriosa'
-groupLogo: 'https://vigotech.org/images/aindustriosa.png'
+groupLogo: '/images/groups/aindustriosa.png'
 title: '20250322 - Galegos na FOSDEM - Santiago Saavedra'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=Z1Q7z6Whz8A'

--- a/src/content/videos/gdgvigo/85v3pl50yl4.md
+++ b/src/content/videos/gdgvigo/85v3pl50yl4.md
@@ -2,7 +2,7 @@
 sourceId: '85V3Pl50Yl4'
 groupId: 'gdgvigo'
 groupName: 'GDG Vigo'
-groupLogo: 'https://vigotech.org/images/gdg_vigo.png'
+groupLogo: '/images/groups/gdg_vigo.png'
 title: 'GDG Vigo - Web Components y Polymer'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=85V3Pl50Yl4'

--- a/src/content/videos/gdgvigo/rlcej7ob2yq.md
+++ b/src/content/videos/gdgvigo/rlcej7ob2yq.md
@@ -2,7 +2,7 @@
 sourceId: 'RLceJ7Ob2yQ'
 groupId: 'gdgvigo'
 groupName: 'GDG Vigo'
-groupLogo: 'https://vigotech.org/images/gdg_vigo.png'
+groupLogo: '/images/groups/gdg_vigo.png'
 title: 'Floppy disks By Breogan and Alberto'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=RLceJ7Ob2yQ'

--- a/src/content/videos/gdgvigo/u4kykubpg6c.md
+++ b/src/content/videos/gdgvigo/u4kykubpg6c.md
@@ -2,7 +2,7 @@
 sourceId: 'u4KYKUbpg6c'
 groupId: 'gdgvigo'
 groupName: 'GDG Vigo'
-groupLogo: 'https://vigotech.org/images/gdg_vigo.png'
+groupLogo: '/images/groups/gdg_vigo.png'
 title: 'GDG Vigo - Python y Django'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=u4KYKUbpg6c'

--- a/src/content/videos/phpvigo/2cx3zyjthmm.md
+++ b/src/content/videos/phpvigo/2cx3zyjthmm.md
@@ -2,7 +2,7 @@
 sourceId: '2cx3ZyJTHmM'
 groupId: 'phpvigo'
 groupName: 'PHPVigo'
-groupLogo: 'https://vigotech.org/images/php_vigo.jpg'
+groupLogo: '/images/groups/php_vigo.jpg'
 title: 'Charla sobre GIT por Jesus Amieiro en #PHPVigo Meetup #2'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=2cx3ZyJTHmM'

--- a/src/content/videos/phpvigo/304ikjdidg8.md
+++ b/src/content/videos/phpvigo/304ikjdidg8.md
@@ -2,7 +2,7 @@
 sourceId: '304IKjdiDG8'
 groupId: 'phpvigo'
 groupName: 'PHPVigo'
-groupLogo: 'https://vigotech.org/images/php_vigo.jpg'
+groupLogo: '/images/groups/php_vigo.jpg'
 title: 'Zend Certified Engineer (Orestes Carracedo)'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=304IKjdiDG8'

--- a/src/content/videos/phpvigo/3n3ak0dyjq4.md
+++ b/src/content/videos/phpvigo/3n3ak0dyjq4.md
@@ -2,7 +2,7 @@
 sourceId: '3n3aK0DYJq4'
 groupId: 'phpvigo'
 groupName: 'PHPVigo'
-groupLogo: 'https://vigotech.org/images/php_vigo.jpg'
+groupLogo: '/images/groups/php_vigo.jpg'
 title: 'Novedades PHP 7.2 con Raúl Araya'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=3n3aK0DYJq4'

--- a/src/content/videos/phpvigo/3wsdxmk9miw.md
+++ b/src/content/videos/phpvigo/3wsdxmk9miw.md
@@ -2,7 +2,7 @@
 sourceId: '3WSDxMK9MIw'
 groupId: 'phpvigo'
 groupName: 'PHPVigo'
-groupLogo: 'https://vigotech.org/images/php_vigo.jpg'
+groupLogo: '/images/groups/php_vigo.jpg'
 title: 'PHPVigo #40: New no, lo siguiente. Patrones de creación de objetos 🔊 Fran  Iglesias'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=3WSDxMK9MIw'

--- a/src/content/videos/phpvigo/4hsgawqb20g.md
+++ b/src/content/videos/phpvigo/4hsgawqb20g.md
@@ -2,7 +2,7 @@
 sourceId: '4HsGaWqB20g'
 groupId: 'phpvigo'
 groupName: 'PHPVigo'
-groupLogo: 'https://vigotech.org/images/php_vigo.jpg'
+groupLogo: '/images/groups/php_vigo.jpg'
 title: '2017 04 26 21 44 12'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=4HsGaWqB20g'

--- a/src/content/videos/phpvigo/7eq6wcsi6ik.md
+++ b/src/content/videos/phpvigo/7eq6wcsi6ik.md
@@ -2,7 +2,7 @@
 sourceId: '7eQ6WCsi6ik'
 groupId: 'phpvigo'
 groupName: 'PHPVigo'
-groupLogo: 'https://vigotech.org/images/php_vigo.jpg'
+groupLogo: '/images/groups/php_vigo.jpg'
 title: 'Charla presentación PHPVigo #PHPVigo Meetup#1'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=7eQ6WCsi6ik'

--- a/src/content/videos/phpvigo/8mrfrbyffpm.md
+++ b/src/content/videos/phpvigo/8mrfrbyffpm.md
@@ -2,7 +2,7 @@
 sourceId: '8mRFrByfFpM'
 groupId: 'phpvigo'
 groupName: 'PHPVigo'
-groupLogo: 'https://vigotech.org/images/php_vigo.jpg'
+groupLogo: '/images/groups/php_vigo.jpg'
 title: 'Double Extension Attack (@sergiocarracedo)'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=8mRFrByfFpM'

--- a/src/content/videos/phpvigo/bteb03r2hpo.md
+++ b/src/content/videos/phpvigo/bteb03r2hpo.md
@@ -2,7 +2,7 @@
 sourceId: 'bteb03R2hpo'
 groupId: 'phpvigo'
 groupName: 'PHPVigo'
-groupLogo: 'https://vigotech.org/images/php_vigo.jpg'
+groupLogo: '/images/groups/php_vigo.jpg'
 title: 'DÃ³nde estÃ¡ mi Ã±" -Miguel Gonzalez (@migonzalvar)'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=bteb03R2hpo'

--- a/src/content/videos/phpvigo/cb3fhly1sc4.md
+++ b/src/content/videos/phpvigo/cb3fhly1sc4.md
@@ -2,7 +2,7 @@
 sourceId: 'cB3fHLy1Sc4'
 groupId: 'phpvigo'
 groupName: 'PHPVigo'
-groupLogo: 'https://vigotech.org/images/php_vigo.jpg'
+groupLogo: '/images/groups/php_vigo.jpg'
 title: 'Postgresql 101 - Eloy Coto (@eloycoto)'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=cB3fHLy1Sc4'

--- a/src/content/videos/phpvigo/d2vqjesbl-e.md
+++ b/src/content/videos/phpvigo/d2vqjesbl-e.md
@@ -2,7 +2,7 @@
 sourceId: 'D2VqJesbL-E'
 groupId: 'phpvigo'
 groupName: 'PHPVigo'
-groupLogo: 'https://vigotech.org/images/php_vigo.jpg'
+groupLogo: '/images/groups/php_vigo.jpg'
 title: 'Métodos mágicos II (Rolando Caldas)'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=D2VqJesbL-E'

--- a/src/content/videos/phpvigo/dz8gidh9j9k.md
+++ b/src/content/videos/phpvigo/dz8gidh9j9k.md
@@ -2,7 +2,7 @@
 sourceId: 'Dz8giDh9j9k'
 groupId: 'phpvigo'
 groupName: 'PHPVigo'
-groupLogo: 'https://vigotech.org/images/php_vigo.jpg'
+groupLogo: '/images/groups/php_vigo.jpg'
 title: 'Métodos mágicos (Rolando Caldas Sánchez)'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=Dz8giDh9j9k'

--- a/src/content/videos/phpvigo/fzxgpe6ki3g.md
+++ b/src/content/videos/phpvigo/fzxgpe6ki3g.md
@@ -2,7 +2,7 @@
 sourceId: 'fZxGpE6ki3g'
 groupId: 'phpvigo'
 groupName: 'PHPVigo'
-groupLogo: 'https://vigotech.org/images/php_vigo.jpg'
+groupLogo: '/images/groups/php_vigo.jpg'
 title: 'Conectar a MySQL correctamente (Jose Antonio González López)'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=fZxGpE6ki3g'

--- a/src/content/videos/phpvigo/gibqyfj2k5g.md
+++ b/src/content/videos/phpvigo/gibqyfj2k5g.md
@@ -2,7 +2,7 @@
 sourceId: 'GIbQYfj2K5g'
 groupId: 'phpvigo'
 groupName: 'PHPVigo'
-groupLogo: 'https://vigotech.org/images/php_vigo.jpg'
+groupLogo: '/images/groups/php_vigo.jpg'
 title: 'Blackfire.io: Mide tu performance (Ruben Gonzalez)'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=GIbQYfj2K5g'

--- a/src/content/videos/phpvigo/iyj-extcbyq.md
+++ b/src/content/videos/phpvigo/iyj-extcbyq.md
@@ -2,7 +2,7 @@
 sourceId: 'iyj-exTcbyQ'
 groupId: 'phpvigo'
 groupName: 'PHPVigo'
-groupLogo: 'https://vigotech.org/images/php_vigo.jpg'
+groupLogo: '/images/groups/php_vigo.jpg'
 title: 'PHPVigo #38: "Monta una API con ReactPHP" (Dev Streaming)'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=iyj-exTcbyQ'

--- a/src/content/videos/phpvigo/kojcoyysprm.md
+++ b/src/content/videos/phpvigo/kojcoyysprm.md
@@ -2,7 +2,7 @@
 sourceId: 'KOJcOyySPRM'
 groupId: 'phpvigo'
 groupName: 'PHPVigo'
-groupLogo: 'https://vigotech.org/images/php_vigo.jpg'
+groupLogo: '/images/groups/php_vigo.jpg'
 title: 'DÃ³nde estÃ¡ mi Ã±'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=KOJcOyySPRM'

--- a/src/content/videos/phpvigo/kwydgooyo2o.md
+++ b/src/content/videos/phpvigo/kwydgooyo2o.md
@@ -2,7 +2,7 @@
 sourceId: 'KwydgooyO2o'
 groupId: 'phpvigo'
 groupName: 'PHPVigo'
-groupLogo: 'https://vigotech.org/images/php_vigo.jpg'
+groupLogo: '/images/groups/php_vigo.jpg'
 title: 'Symfony 4 con David Negreira'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=KwydgooyO2o'

--- a/src/content/videos/phpvigo/loq7ztwd5ti.md
+++ b/src/content/videos/phpvigo/loq7ztwd5ti.md
@@ -2,7 +2,7 @@
 sourceId: 'LOQ7zTWD5tI'
 groupId: 'phpvigo'
 groupName: 'PHPVigo'
-groupLogo: 'https://vigotech.org/images/php_vigo.jpg'
+groupLogo: '/images/groups/php_vigo.jpg'
 title: 'Arrays y Js, vamos a jugar - David García (@tansitos)'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=LOQ7zTWD5tI'

--- a/src/content/videos/phpvigo/lvk88gcu7-q.md
+++ b/src/content/videos/phpvigo/lvk88gcu7-q.md
@@ -2,7 +2,7 @@
 sourceId: 'LVK88Gcu7-Q'
 groupId: 'phpvigo'
 groupName: 'PHPVigo'
-groupLogo: 'https://vigotech.org/images/php_vigo.jpg'
+groupLogo: '/images/groups/php_vigo.jpg'
 title: 'Preprocesadores CSS'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=LVK88Gcu7-Q'

--- a/src/content/videos/phpvigo/nbep64e8dzq.md
+++ b/src/content/videos/phpvigo/nbep64e8dzq.md
@@ -2,7 +2,7 @@
 sourceId: 'NbeP64e8DZQ'
 groupId: 'phpvigo'
 groupName: 'PHPVigo'
-groupLogo: 'https://vigotech.org/images/php_vigo.jpg'
+groupLogo: '/images/groups/php_vigo.jpg'
 title: 'CSS Grid Layout: El futuro ya está aquí'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=NbeP64e8DZQ'

--- a/src/content/videos/phpvigo/nftbtvstshe.md
+++ b/src/content/videos/phpvigo/nftbtvstshe.md
@@ -2,7 +2,7 @@
 sourceId: 'NftbtvsTShE'
 groupId: 'phpvigo'
 groupName: 'PHPVigo'
-groupLogo: 'https://vigotech.org/images/php_vigo.jpg'
+groupLogo: '/images/groups/php_vigo.jpg'
 title: 'Meetup #15: ¡No sin Composer! Carlos Goce (@carlosgoce)'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=NftbtvsTShE'

--- a/src/content/videos/phpvigo/nkrt5d-jzti.md
+++ b/src/content/videos/phpvigo/nkrt5d-jzti.md
@@ -2,7 +2,7 @@
 sourceId: 'Nkrt5d_jZtI'
 groupId: 'phpvigo'
 groupName: 'PHPVigo'
-groupLogo: 'https://vigotech.org/images/php_vigo.jpg'
+groupLogo: '/images/groups/php_vigo.jpg'
 title: 'PHPVigo   Drupal'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=Nkrt5d_jZtI'

--- a/src/content/videos/phpvigo/nxktclql-oy.md
+++ b/src/content/videos/phpvigo/nxktclql-oy.md
@@ -2,7 +2,7 @@
 sourceId: 'nxKtcLQl-OY'
 groupId: 'phpvigo'
 groupName: 'PHPVigo'
-groupLogo: 'https://vigotech.org/images/php_vigo.jpg'
+groupLogo: '/images/groups/php_vigo.jpg'
 title: 'Resque: Workers Asíncronos (Sergio Carracedo)'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=nxKtcLQl-OY'

--- a/src/content/videos/phpvigo/o8-24tjp-2o.md
+++ b/src/content/videos/phpvigo/o8-24tjp-2o.md
@@ -2,7 +2,7 @@
 sourceId: 'o8_24tjP-2o'
 groupId: 'phpvigo'
 groupName: 'PHPVigo'
-groupLogo: 'https://vigotech.org/images/php_vigo.jpg'
+groupLogo: '/images/groups/php_vigo.jpg'
 title: 'Charla Introducción a Joomla por Pablo Arias - #PHPVigo Meetup #2'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=o8_24tjP-2o'

--- a/src/content/videos/phpvigo/ouz-mqfccuy.md
+++ b/src/content/videos/phpvigo/ouz-mqfccuy.md
@@ -2,7 +2,7 @@
 sourceId: 'oUZ-mqFcCuY'
 groupId: 'phpvigo'
 groupName: 'PHPVigo'
-groupLogo: 'https://vigotech.org/images/php_vigo.jpg'
+groupLogo: '/images/groups/php_vigo.jpg'
 title: 'Testing && Pizza - Álvaro Gómez (@lito_ordes)'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=oUZ-mqFcCuY'

--- a/src/content/videos/phpvigo/p4vdylusqhw.md
+++ b/src/content/videos/phpvigo/p4vdylusqhw.md
@@ -2,7 +2,7 @@
 sourceId: 'p4vdyLUsqHw'
 groupId: 'phpvigo'
 groupName: 'PHPVigo'
-groupLogo: 'https://vigotech.org/images/php_vigo.jpg'
+groupLogo: '/images/groups/php_vigo.jpg'
 title: 'Encabezados HTTP de seguridade @rocasan_'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=p4vdyLUsqHw'

--- a/src/content/videos/phpvigo/q4vl54asnai.md
+++ b/src/content/videos/phpvigo/q4vl54asnai.md
@@ -2,7 +2,7 @@
 sourceId: 'q4Vl54AsnaI'
 groupId: 'phpvigo'
 groupName: 'PHPVigo'
-groupLogo: 'https://vigotech.org/images/php_vigo.jpg'
+groupLogo: '/images/groups/php_vigo.jpg'
 title: 'Felicitacion PHPVigo 2016'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=q4Vl54AsnaI'

--- a/src/content/videos/phpvigo/qkrdzyq6oai.md
+++ b/src/content/videos/phpvigo/qkrdzyq6oai.md
@@ -2,7 +2,7 @@
 sourceId: 'QKRdzyq6oAI'
 groupId: 'phpvigo'
 groupName: 'PHPVigo'
-groupLogo: 'https://vigotech.org/images/php_vigo.jpg'
+groupLogo: '/images/groups/php_vigo.jpg'
 title: 'Charla sobre Ansible por Orestes Carracedo -  #PHPVigo Meetup#1'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=QKRdzyq6oAI'

--- a/src/content/videos/phpvigo/rffmsqrfml8.md
+++ b/src/content/videos/phpvigo/rffmsqrfml8.md
@@ -2,7 +2,7 @@
 sourceId: 'rffMsQRFml8'
 groupId: 'phpvigo'
 groupName: 'PHPVigo'
-groupLogo: 'https://vigotech.org/images/php_vigo.jpg'
+groupLogo: '/images/groups/php_vigo.jpg'
 title: 'phpVigo   AWS'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=rffMsQRFml8'

--- a/src/content/videos/phpvigo/sclgm6jitik.md
+++ b/src/content/videos/phpvigo/sclgm6jitik.md
@@ -2,7 +2,7 @@
 sourceId: 'ScLGm6jitik'
 groupId: 'phpvigo'
 groupName: 'PHPVigo'
-groupLogo: 'https://vigotech.org/images/php_vigo.jpg'
+groupLogo: '/images/groups/php_vigo.jpg'
 title: 'Meetup#7: AWS Reload y Despliegue con Deployer'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=ScLGm6jitik'

--- a/src/content/videos/phpvigo/svqewpbjkva.md
+++ b/src/content/videos/phpvigo/svqewpbjkva.md
@@ -2,7 +2,7 @@
 sourceId: 'svqEwpbjkvA'
 groupId: 'phpvigo'
 groupName: 'PHPVigo'
-groupLogo: 'https://vigotech.org/images/php_vigo.jpg'
+groupLogo: '/images/groups/php_vigo.jpg'
 title: '¿Nos hacen los tests ir más rápidos?'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=svqEwpbjkvA'

--- a/src/content/videos/phpvigo/tugzwmsf-mk.md
+++ b/src/content/videos/phpvigo/tugzwmsf-mk.md
@@ -2,7 +2,7 @@
 sourceId: 'TuGZWmsf-Mk'
 groupId: 'phpvigo'
 groupName: 'PHPVigo'
-groupLogo: 'https://vigotech.org/images/php_vigo.jpg'
+groupLogo: '/images/groups/php_vigo.jpg'
 title: 'Meetup #12: "Performance blackfire.io"'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=TuGZWmsf-Mk'

--- a/src/content/videos/phpvigo/txwbsvm2rx0.md
+++ b/src/content/videos/phpvigo/txwbsvm2rx0.md
@@ -2,7 +2,7 @@
 sourceId: 'txWbsVM2Rx0'
 groupId: 'phpvigo'
 groupName: 'PHPVigo'
-groupLogo: 'https://vigotech.org/images/php_vigo.jpg'
+groupLogo: '/images/groups/php_vigo.jpg'
 title: 'PHP Slim Api Rest (Fernando Freire)'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=txWbsVM2Rx0'

--- a/src/content/videos/phpvigo/uc1f88sgfji.md
+++ b/src/content/videos/phpvigo/uc1f88sgfji.md
@@ -2,7 +2,7 @@
 sourceId: 'uC1f88SGFJI'
 groupId: 'phpvigo'
 groupName: 'PHPVigo'
-groupLogo: 'https://vigotech.org/images/php_vigo.jpg'
+groupLogo: '/images/groups/php_vigo.jpg'
 title: 'Facturascripts 2018 técnico'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=uC1f88SGFJI'

--- a/src/content/videos/phpvigo/udzna9mbibw.md
+++ b/src/content/videos/phpvigo/udzna9mbibw.md
@@ -2,7 +2,7 @@
 sourceId: 'uDzna9mbIBw'
 groupId: 'phpvigo'
 groupName: 'PHPVigo'
-groupLogo: 'https://vigotech.org/images/php_vigo.jpg'
+groupLogo: '/images/groups/php_vigo.jpg'
 title: '"API REST" - Bueno Bonito Barato'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=uDzna9mbIBw'

--- a/src/content/videos/phpvigo/ufgsmaza42c.md
+++ b/src/content/videos/phpvigo/ufgsmaza42c.md
@@ -2,7 +2,7 @@
 sourceId: 'ufGsMAzA42c'
 groupId: 'phpvigo'
 groupName: 'PHPVigo'
-groupLogo: 'https://vigotech.org/images/php_vigo.jpg'
+groupLogo: '/images/groups/php_vigo.jpg'
 title: 'Rolando Caldas - Password Hash'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=ufGsMAzA42c'

--- a/src/content/videos/phpvigo/uhpfamewhds.md
+++ b/src/content/videos/phpvigo/uhpfamewhds.md
@@ -2,7 +2,7 @@
 sourceId: 'UhPfaMEWHDs'
 groupId: 'phpvigo'
 groupName: 'PHPVigo'
-groupLogo: 'https://vigotech.org/images/php_vigo.jpg'
+groupLogo: '/images/groups/php_vigo.jpg'
 title: 'Preprocesadores CSS'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=UhPfaMEWHDs'

--- a/src/content/videos/phpvigo/umssjhe5yg0.md
+++ b/src/content/videos/phpvigo/umssjhe5yg0.md
@@ -2,7 +2,7 @@
 sourceId: 'umssjHE5yG0'
 groupId: 'phpvigo'
 groupName: 'PHPVigo'
-groupLogo: 'https://vigotech.org/images/php_vigo.jpg'
+groupLogo: '/images/groups/php_vigo.jpg'
 title: 'Filter Input (@rolando_caldas)'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=umssjHE5yG0'

--- a/src/content/videos/phpvigo/vvbdoctin44.md
+++ b/src/content/videos/phpvigo/vvbdoctin44.md
@@ -2,7 +2,7 @@
 sourceId: 'VVbdoCTiN44'
 groupId: 'phpvigo'
 groupName: 'PHPVigo'
-groupLogo: 'https://vigotech.org/images/php_vigo.jpg'
+groupLogo: '/images/groups/php_vigo.jpg'
 title: 'Shame on you PHP!! (Sergio Carracedo)'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=VVbdoCTiN44'

--- a/src/content/videos/phpvigo/wyluexr7v-m.md
+++ b/src/content/videos/phpvigo/wyluexr7v-m.md
@@ -2,7 +2,7 @@
 sourceId: 'wyLUeXr7v_M'
 groupId: 'phpvigo'
 groupName: 'PHPVigo'
-groupLogo: 'https://vigotech.org/images/php_vigo.jpg'
+groupLogo: '/images/groups/php_vigo.jpg'
 title: 'Meetup #12: "Gestionar un WP con 250k pv diarias"'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=wyLUeXr7v_M'

--- a/src/content/videos/phpvigo/ylwj3n6hjxy.md
+++ b/src/content/videos/phpvigo/ylwj3n6hjxy.md
@@ -2,7 +2,7 @@
 sourceId: 'ylWJ3n6HJXY'
 groupId: 'phpvigo'
 groupName: 'PHPVigo'
-groupLogo: 'https://vigotech.org/images/php_vigo.jpg'
+groupLogo: '/images/groups/php_vigo.jpg'
 title: '2017 03 22 21 26 38'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=ylWJ3n6HJXY'

--- a/src/content/videos/phpvigo/yzoyqg1niro.md
+++ b/src/content/videos/phpvigo/yzoyqg1niro.md
@@ -2,7 +2,7 @@
 sourceId: 'yzoyQg1NIRo'
 groupId: 'phpvigo'
 groupName: 'PHPVigo'
-groupLogo: 'https://vigotech.org/images/php_vigo.jpg'
+groupLogo: '/images/groups/php_vigo.jpg'
 title: 'PHP Traits (Carlos Goce)'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=yzoyQg1NIRo'

--- a/src/content/videos/phpvigo/z-k5iusjcdo.md
+++ b/src/content/videos/phpvigo/z-k5iusjcdo.md
@@ -2,7 +2,7 @@
 sourceId: 'z_K5iuSjCDo'
 groupId: 'phpvigo'
 groupName: 'PHPVigo'
-groupLogo: 'https://vigotech.org/images/php_vigo.jpg'
+groupLogo: '/images/groups/php_vigo.jpg'
 title: 'PHPVigo 39: "Crea tu propia librería de componentes Vue. From scratch to NPM"'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=z_K5iuSjCDo'

--- a/src/content/videos/phpvigo/zix6z-xyn90.md
+++ b/src/content/videos/phpvigo/zix6z-xyn90.md
@@ -2,7 +2,7 @@
 sourceId: 'ZIX6z-xYN90'
 groupId: 'phpvigo'
 groupName: 'PHPVigo'
-groupLogo: 'https://vigotech.org/images/php_vigo.jpg'
+groupLogo: '/images/groups/php_vigo.jpg'
 title: 'Jenkins: Deja ya de hacerlo a mano!" - Santiago Rodriguez Collazo'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=ZIX6z-xYN90'

--- a/src/content/videos/phpvigo/zizo5kqm-ku.md
+++ b/src/content/videos/phpvigo/zizo5kqm-ku.md
@@ -2,7 +2,7 @@
 sourceId: 'ziZO5KQM_KU'
 groupId: 'phpvigo'
 groupName: 'PHPVigo'
-groupLogo: 'https://vigotech.org/images/php_vigo.jpg'
+groupLogo: '/images/groups/php_vigo.jpg'
 title: 'PHPVigo #37 - La nueva normalidad dev stream'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=ziZO5KQM_KU'

--- a/src/content/videos/pythonvigo/09hftif-fae.md
+++ b/src/content/videos/pythonvigo/09hftif-fae.md
@@ -2,7 +2,7 @@
 sourceId: '09hfTif_FaE'
 groupId: 'pythonvigo'
 groupName: 'PythonVigo'
-groupLogo: 'https://vigotech.org/images/python_vigo.png'
+groupLogo: '/images/groups/python_vigo.png'
 title: 'Algoritmo Binary Search, por Antón Yuste'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=09hfTif_FaE'

--- a/src/content/videos/pythonvigo/1d7vqkrgdt4.md
+++ b/src/content/videos/pythonvigo/1d7vqkrgdt4.md
@@ -2,7 +2,7 @@
 sourceId: '1D7VQKRgDT4'
 groupId: 'pythonvigo'
 groupName: 'PythonVigo'
-groupLogo: 'https://vigotech.org/images/python_vigo.png'
+groupLogo: '/images/groups/python_vigo.png'
 title: 'Type Hinting básico, por Xurxo Fresco'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=1D7VQKRgDT4'

--- a/src/content/videos/pythonvigo/2qqrao0zioc.md
+++ b/src/content/videos/pythonvigo/2qqrao0zioc.md
@@ -2,7 +2,7 @@
 sourceId: '2qQraO0ZIoc'
 groupId: 'pythonvigo'
 groupName: 'PythonVigo'
-groupLogo: 'https://vigotech.org/images/python_vigo.png'
+groupLogo: '/images/groups/python_vigo.png'
 title: 'Acto de apertura PyConEs'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=2qQraO0ZIoc'

--- a/src/content/videos/pythonvigo/2x72htztglu.md
+++ b/src/content/videos/pythonvigo/2x72htztglu.md
@@ -2,7 +2,7 @@
 sourceId: '2X72HTZTgLU'
 groupId: 'pythonvigo'
 groupName: 'PythonVigo'
-groupLogo: 'https://vigotech.org/images/python_vigo.png'
+groupLogo: '/images/groups/python_vigo.png'
 title: 'Introducción a Machine Learning con Python - Xurxo Fresco - PyDay'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=2X72HTZTgLU'

--- a/src/content/videos/pythonvigo/49klm6h8sg8.md
+++ b/src/content/videos/pythonvigo/49klm6h8sg8.md
@@ -2,7 +2,7 @@
 sourceId: '49KlM6h8sg8'
 groupId: 'pythonvigo'
 groupName: 'PythonVigo'
-groupLogo: 'https://vigotech.org/images/python_vigo.png'
+groupLogo: '/images/groups/python_vigo.png'
 title: 'Acto de apertura PyConEs'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=49KlM6h8sg8'

--- a/src/content/videos/pythonvigo/6nirycubxpk.md
+++ b/src/content/videos/pythonvigo/6nirycubxpk.md
@@ -2,7 +2,7 @@
 sourceId: '6niRYcubxPk'
 groupId: 'pythonvigo'
 groupName: 'PythonVigo'
-groupLogo: 'https://vigotech.org/images/python_vigo.png'
+groupLogo: '/images/groups/python_vigo.png'
 title: 'Entornos Interactivos en python'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=6niRYcubxPk'

--- a/src/content/videos/pythonvigo/7u7veo8ahlk.md
+++ b/src/content/videos/pythonvigo/7u7veo8ahlk.md
@@ -2,7 +2,7 @@
 sourceId: '7U7vEO8AHlk'
 groupId: 'pythonvigo'
 groupName: 'PythonVigo'
-groupLogo: 'https://vigotech.org/images/python_vigo.png'
+groupLogo: '/images/groups/python_vigo.png'
 title: 'Cómo evitar alucinaciones en ChatGPT con la arquitectura RAG por Maryna Bogdan'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=7U7vEO8AHlk'

--- a/src/content/videos/pythonvigo/9dptfapk8co.md
+++ b/src/content/videos/pythonvigo/9dptfapk8co.md
@@ -2,7 +2,7 @@
 sourceId: '9DPtfApk8co'
 groupId: 'pythonvigo'
 groupName: 'PythonVigo'
-groupLogo: 'https://vigotech.org/images/python_vigo.png'
+groupLogo: '/images/groups/python_vigo.png'
 title: 'Emisión en directo Python Vigo'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=9DPtfApk8co'

--- a/src/content/videos/pythonvigo/9p7qyb7leba.md
+++ b/src/content/videos/pythonvigo/9p7qyb7leba.md
@@ -2,7 +2,7 @@
 sourceId: '9P7qyb7leBA'
 groupId: 'pythonvigo'
 groupName: 'PythonVigo'
-groupLogo: 'https://vigotech.org/images/python_vigo.png'
+groupLogo: '/images/groups/python_vigo.png'
 title: 'Fixtures and factories by Hector Cantó'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=9P7qyb7leBA'

--- a/src/content/videos/pythonvigo/cfq-1h7bxjk.md
+++ b/src/content/videos/pythonvigo/cfq-1h7bxjk.md
@@ -2,7 +2,7 @@
 sourceId: 'cfQ-1H7bXjk'
 groupId: 'pythonvigo'
 groupName: 'PythonVigo'
-groupLogo: 'https://vigotech.org/images/python_vigo.png'
+groupLogo: '/images/groups/python_vigo.png'
 title: 'Mira mamá, sin ifs - Miguel González'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=cfQ-1H7bXjk'

--- a/src/content/videos/pythonvigo/d5vmtg95ov0.md
+++ b/src/content/videos/pythonvigo/d5vmtg95ov0.md
@@ -2,7 +2,7 @@
 sourceId: 'D5vmTg95Ov0'
 groupId: 'pythonvigo'
 groupName: 'PythonVigo'
-groupLogo: 'https://vigotech.org/images/python_vigo.png'
+groupLogo: '/images/groups/python_vigo.png'
 title: 'Python 3, Primeros pasos.'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=D5vmTg95Ov0'

--- a/src/content/videos/pythonvigo/d7y88pmfnoe.md
+++ b/src/content/videos/pythonvigo/d7y88pmfnoe.md
@@ -2,7 +2,7 @@
 sourceId: 'd7y88pMfNoE'
 groupId: 'pythonvigo'
 groupName: 'PythonVigo'
-groupLogo: 'https://vigotech.org/images/python_vigo.png'
+groupLogo: '/images/groups/python_vigo.png'
 title: '¡Eureka! (Python y ciencia) - ¡Eureka! (Python y ciencia) - PyDay Galicia'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=d7y88pMfNoE'

--- a/src/content/videos/pythonvigo/ef4lltomzkw.md
+++ b/src/content/videos/pythonvigo/ef4lltomzkw.md
@@ -2,7 +2,7 @@
 sourceId: 'ef4LLtomZKw'
 groupId: 'pythonvigo'
 groupName: 'PythonVigo'
-groupLogo: 'https://vigotech.org/images/python_vigo.png'
+groupLogo: '/images/groups/python_vigo.png'
 title: 'PythonVigo - oklog - José COrral'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=ef4LLtomZKw'

--- a/src/content/videos/pythonvigo/ftzawsabxc0.md
+++ b/src/content/videos/pythonvigo/ftzawsabxc0.md
@@ -2,7 +2,7 @@
 sourceId: 'fTZAWsABXc0'
 groupId: 'pythonvigo'
 groupName: 'PythonVigo'
-groupLogo: 'https://vigotech.org/images/python_vigo.png'
+groupLogo: '/images/groups/python_vigo.png'
 title: 'Creando tu propio simulador cuántico en 200 líneas por Ismael Faro'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=fTZAWsABXc0'

--- a/src/content/videos/pythonvigo/fwgppsiyg-o.md
+++ b/src/content/videos/pythonvigo/fwgppsiyg-o.md
@@ -2,7 +2,7 @@
 sourceId: 'FwgpPsiYg_o'
 groupId: 'pythonvigo'
 groupName: 'PythonVigo'
-groupLogo: 'https://vigotech.org/images/python_vigo.png'
+groupLogo: '/images/groups/python_vigo.png'
 title: 'PythonVigo - jython - Antón R. Yuste'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=FwgpPsiYg_o'

--- a/src/content/videos/pythonvigo/gqvhybceimy.md
+++ b/src/content/videos/pythonvigo/gqvhybceimy.md
@@ -2,7 +2,7 @@
 sourceId: 'gqvhYBCeiMY'
 groupId: 'pythonvigo'
 groupName: 'PythonVigo'
-groupLogo: 'https://vigotech.org/images/python_vigo.png'
+groupLogo: '/images/groups/python_vigo.png'
 title: 'Docker en producción - José Corral'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=gqvhYBCeiMY'

--- a/src/content/videos/pythonvigo/hjx-lqllrhw.md
+++ b/src/content/videos/pythonvigo/hjx-lqllrhw.md
@@ -2,7 +2,7 @@
 sourceId: 'hjx-lqLlrhw'
 groupId: 'pythonvigo'
 groupName: 'PythonVigo'
-groupLogo: 'https://vigotech.org/images/python_vigo.png'
+groupLogo: '/images/groups/python_vigo.png'
 title: 'PythonVigo - David de la Iglesia'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=hjx-lqLlrhw'

--- a/src/content/videos/pythonvigo/hqxbvk4vi9m.md
+++ b/src/content/videos/pythonvigo/hqxbvk4vi9m.md
@@ -2,7 +2,7 @@
 sourceId: 'hqXBVk4vI9M'
 groupId: 'pythonvigo'
 groupName: 'PythonVigo'
-groupLogo: 'https://vigotech.org/images/python_vigo.png'
+groupLogo: '/images/groups/python_vigo.png'
 title: 'Python bajo el agua. Aplicaciones python para vehículos submarinos por Ignacio González Liaño'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=hqXBVk4vI9M'

--- a/src/content/videos/pythonvigo/iy-6vy-m60y.md
+++ b/src/content/videos/pythonvigo/iy-6vy-m60y.md
@@ -2,7 +2,7 @@
 sourceId: 'IY_6vY-M60Y'
 groupId: 'pythonvigo'
 groupName: 'PythonVigo'
-groupLogo: 'https://vigotech.org/images/python_vigo.png'
+groupLogo: '/images/groups/python_vigo.png'
 title: 'Metodos magicos python'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=IY_6vY-M60Y'

--- a/src/content/videos/pythonvigo/l8org4kzboi.md
+++ b/src/content/videos/pythonvigo/l8org4kzboi.md
@@ -2,7 +2,7 @@
 sourceId: 'l8ORg4kzBoI'
 groupId: 'pythonvigo'
 groupName: 'PythonVigo'
-groupLogo: 'https://vigotech.org/images/python_vigo.png'
+groupLogo: '/images/groups/python_vigo.png'
 title: 'Resolviendo la kata Args con TDD, por Javier Sánchez'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=l8ORg4kzBoI'

--- a/src/content/videos/pythonvigo/lms4x-1cz-c.md
+++ b/src/content/videos/pythonvigo/lms4x-1cz-c.md
@@ -2,7 +2,7 @@
 sourceId: 'lmS4x_1Cz-c'
 groupId: 'pythonvigo'
 groupName: 'PythonVigo'
-groupLogo: 'https://vigotech.org/images/python_vigo.png'
+groupLogo: '/images/groups/python_vigo.png'
 title: 'PythonVigo - logging - Miguel Gonzalez'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=lmS4x_1Cz-c'

--- a/src/content/videos/pythonvigo/m8s3styumfs.md
+++ b/src/content/videos/pythonvigo/m8s3styumfs.md
@@ -2,7 +2,7 @@
 sourceId: 'M8s3styUMFs'
 groupId: 'pythonvigo'
 groupName: 'PythonVigo'
-groupLogo: 'https://vigotech.org/images/python_vigo.png'
+groupLogo: '/images/groups/python_vigo.png'
 title: 'Acto de apertura PyConEs'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=M8s3styUMFs'

--- a/src/content/videos/pythonvigo/micqgdqrzxm.md
+++ b/src/content/videos/pythonvigo/micqgdqrzxm.md
@@ -2,7 +2,7 @@
 sourceId: 'miCqgdqrZXM'
 groupId: 'pythonvigo'
 groupName: 'PythonVigo'
-groupLogo: 'https://vigotech.org/images/python_vigo.png'
+groupLogo: '/images/groups/python_vigo.png'
 title: 'Acto de apertura PyConEs'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=miCqgdqrZXM'

--- a/src/content/videos/pythonvigo/npstutu8qxc.md
+++ b/src/content/videos/pythonvigo/npstutu8qxc.md
@@ -2,7 +2,7 @@
 sourceId: 'NPsTUtU8QXc'
 groupId: 'pythonvigo'
 groupName: 'PythonVigo'
-groupLogo: 'https://vigotech.org/images/python_vigo.png'
+groupLogo: '/images/groups/python_vigo.png'
 title: 'Emisión en directo Python Vigo'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=NPsTUtU8QXc'

--- a/src/content/videos/pythonvigo/omst3ju-rjq.md
+++ b/src/content/videos/pythonvigo/omst3ju-rjq.md
@@ -2,7 +2,7 @@
 sourceId: 'oMst3JU-RjQ'
 groupId: 'pythonvigo'
 groupName: 'PythonVigo'
-groupLogo: 'https://vigotech.org/images/python_vigo.png'
+groupLogo: '/images/groups/python_vigo.png'
 title: 'Measure all the things'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=oMst3JU-RjQ'

--- a/src/content/videos/pythonvigo/phkmzaax3ha.md
+++ b/src/content/videos/pythonvigo/phkmzaax3ha.md
@@ -2,7 +2,7 @@
 sourceId: 'PhkMZaAX3HA'
 groupId: 'pythonvigo'
 groupName: 'PythonVigo'
-groupLogo: 'https://vigotech.org/images/python_vigo.png'
+groupLogo: '/images/groups/python_vigo.png'
 title: 'Tinkering with CLI: Refining your terminal toolbox with pipx por Daniel Sanchez'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=PhkMZaAX3HA'

--- a/src/content/videos/pythonvigo/pw97r0eo7so.md
+++ b/src/content/videos/pythonvigo/pw97r0eo7so.md
@@ -2,7 +2,7 @@
 sourceId: 'pw97r0EO7So'
 groupId: 'pythonvigo'
 groupName: 'PythonVigo'
-groupLogo: 'https://vigotech.org/images/python_vigo.png'
+groupLogo: '/images/groups/python_vigo.png'
 title: 'Emisión en directo Python Vigo'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=pw97r0EO7So'

--- a/src/content/videos/pythonvigo/q7c9-yq6wk.md
+++ b/src/content/videos/pythonvigo/q7c9-yq6wk.md
@@ -2,7 +2,7 @@
 sourceId: 'Q7C9-_yq6wk'
 groupId: 'pythonvigo'
 groupName: 'PythonVigo'
-groupLogo: 'https://vigotech.org/images/python_vigo.png'
+groupLogo: '/images/groups/python_vigo.png'
 title: 'Emisión en directo Python Vigo'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=Q7C9-_yq6wk'

--- a/src/content/videos/pythonvigo/q9c0dqteyc8.md
+++ b/src/content/videos/pythonvigo/q9c0dqteyc8.md
@@ -2,7 +2,7 @@
 sourceId: 'Q9c0dQTEyc8'
 groupId: 'pythonvigo'
 groupName: 'PythonVigo'
-groupLogo: 'https://vigotech.org/images/python_vigo.png'
+groupLogo: '/images/groups/python_vigo.png'
 title: 'Codenamize: presentación de la librería. Por José Juan Montes.'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=Q9c0dQTEyc8'

--- a/src/content/videos/pythonvigo/qfxsn-fc0nq.md
+++ b/src/content/videos/pythonvigo/qfxsn-fc0nq.md
@@ -2,7 +2,7 @@
 sourceId: 'QfXsn_fC0NQ'
 groupId: 'pythonvigo'
 groupName: 'PythonVigo'
-groupLogo: 'https://vigotech.org/images/python_vigo.png'
+groupLogo: '/images/groups/python_vigo.png'
 title: '#GameDev at Python Vigo'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=QfXsn_fC0NQ'

--- a/src/content/videos/pythonvigo/qwf0qd26gwm.md
+++ b/src/content/videos/pythonvigo/qwf0qd26gwm.md
@@ -2,7 +2,7 @@
 sourceId: 'QWF0qd26gWM'
 groupId: 'pythonvigo'
 groupName: 'PythonVigo'
-groupLogo: 'https://vigotech.org/images/python_vigo.png'
+groupLogo: '/images/groups/python_vigo.png'
 title: 'Agile, Scrum y Kanban - Pepe Doval - PyDay Galicia'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=QWF0qd26gWM'

--- a/src/content/videos/pythonvigo/qwhoyvluk-u.md
+++ b/src/content/videos/pythonvigo/qwhoyvluk-u.md
@@ -2,7 +2,7 @@
 sourceId: 'qWHoyvLUK-U'
 groupId: 'pythonvigo'
 groupName: 'PythonVigo'
-groupLogo: 'https://vigotech.org/images/python_vigo.png'
+groupLogo: '/images/groups/python_vigo.png'
 title: 'Mi primera metaclase: un ejemplo práctico - Miguel González Álvarez - PyDay'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=qWHoyvLUK-U'

--- a/src/content/videos/pythonvigo/rodhalbfano.md
+++ b/src/content/videos/pythonvigo/rodhalbfano.md
@@ -2,7 +2,7 @@
 sourceId: 'RODHAlBFANo'
 groupId: 'pythonvigo'
 groupName: 'PythonVigo'
-groupLogo: 'https://vigotech.org/images/python_vigo.png'
+groupLogo: '/images/groups/python_vigo.png'
 title: 'Great balls of fire (Visualizando datos con Dash), por Iván Nieto'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=RODHAlBFANo'

--- a/src/content/videos/pythonvigo/sy233urmikm.md
+++ b/src/content/videos/pythonvigo/sy233urmikm.md
@@ -2,7 +2,7 @@
 sourceId: 'sy233UrMikM'
 groupId: 'pythonvigo'
 groupName: 'PythonVigo'
-groupLogo: 'https://vigotech.org/images/python_vigo.png'
+groupLogo: '/images/groups/python_vigo.png'
 title: 'Luis Rovirosa - Learned lessons in a real world project'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=sy233UrMikM'

--- a/src/content/videos/pythonvigo/t1wih6hs-yw.md
+++ b/src/content/videos/pythonvigo/t1wih6hs-yw.md
@@ -2,7 +2,7 @@
 sourceId: 'T1wih6Hs-Yw'
 groupId: 'pythonvigo'
 groupName: 'PythonVigo'
-groupLogo: 'https://vigotech.org/images/python_vigo.png'
+groupLogo: '/images/groups/python_vigo.png'
 title: 'Brujería con Numpy.einsum, por David de la Iglesia'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=T1wih6Hs-Yw'

--- a/src/content/videos/pythonvigo/v-ctyi8ooli.md
+++ b/src/content/videos/pythonvigo/v-ctyi8ooli.md
@@ -2,7 +2,7 @@
 sourceId: 'V-cTyi8oOLI'
 groupId: 'pythonvigo'
 groupName: 'PythonVigo'
-groupLogo: 'https://vigotech.org/images/python_vigo.png'
+groupLogo: '/images/groups/python_vigo.png'
 title: 'Emisión en directo de Python Vigo'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=V-cTyi8oOLI'

--- a/src/content/videos/pythonvigo/wrl5h0tmq-w.md
+++ b/src/content/videos/pythonvigo/wrl5h0tmq-w.md
@@ -2,7 +2,7 @@
 sourceId: 'WrL5H0Tmq-w'
 groupId: 'pythonvigo'
 groupName: 'PythonVigo'
-groupLogo: 'https://vigotech.org/images/python_vigo.png'
+groupLogo: '/images/groups/python_vigo.png'
 title: 'APIS de Machine Learning: como usarlas desde Python. Por David de la Iglesia.'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=WrL5H0Tmq-w'

--- a/src/content/videos/pythonvigo/xn98drgum7s.md
+++ b/src/content/videos/pythonvigo/xn98drgum7s.md
@@ -2,7 +2,7 @@
 sourceId: 'XN98drGum7s'
 groupId: 'pythonvigo'
 groupName: 'PythonVigo'
-groupLogo: 'https://vigotech.org/images/python_vigo.png'
+groupLogo: '/images/groups/python_vigo.png'
 title: 'Calling to the future - Eloy Coto - PyDay Galicia'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=XN98drGum7s'

--- a/src/content/videos/pythonvigo/y-w9t8kwnz4.md
+++ b/src/content/videos/pythonvigo/y-w9t8kwnz4.md
@@ -2,7 +2,7 @@
 sourceId: 'Y-W9t8KWNz4'
 groupId: 'pythonvigo'
 groupName: 'PythonVigo'
-groupLogo: 'https://vigotech.org/images/python_vigo.png'
+groupLogo: '/images/groups/python_vigo.png'
 title: 'This summer master the mosquittos, por Alex Hermida'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=Y-W9t8KWNz4'

--- a/src/content/videos/pythonvigo/yqzx2m7ay.md
+++ b/src/content/videos/pythonvigo/yqzx2m7ay.md
@@ -2,7 +2,7 @@
 sourceId: '-_Yqzx2M7AY'
 groupId: 'pythonvigo'
 groupName: 'PythonVigo'
-groupLogo: 'https://vigotech.org/images/python_vigo.png'
+groupLogo: '/images/groups/python_vigo.png'
 title: 'Creando tu propio simulador cuántico en 200 líneas por Ismael Faro'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=-_Yqzx2M7AY'

--- a/src/content/videos/pythonvigo/z-azc6hkzk8.md
+++ b/src/content/videos/pythonvigo/z-azc6hkzk8.md
@@ -2,7 +2,7 @@
 sourceId: 'Z_AzC6HkZk8'
 groupId: 'pythonvigo'
 groupName: 'PythonVigo'
-groupLogo: 'https://vigotech.org/images/python_vigo.png'
+groupLogo: '/images/groups/python_vigo.png'
 title: 'Emisión en directo Python Vigo'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=Z_AzC6HkZk8'

--- a/src/content/videos/vigojug/4vdhl-s-fga.md
+++ b/src/content/videos/vigojug/4vdhl-s-fga.md
@@ -2,7 +2,7 @@
 sourceId: '4vDhL_S_FGA'
 groupId: 'vigojug'
 groupName: 'VigoJUG'
-groupLogo: 'https://vigotech.org/images/vigojug.jpg'
+groupLogo: '/images/groups/vigojug.jpg'
 title: 'Laretas AMA: Cristina Vázquez'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=4vDhL_S_FGA'

--- a/src/content/videos/vigojug/4wltqdk0asm.md
+++ b/src/content/videos/vigojug/4wltqdk0asm.md
@@ -2,7 +2,7 @@
 sourceId: '4WlTqDk0ASM'
 groupId: 'vigojug'
 groupName: 'VigoJUG'
-groupLogo: 'https://vigotech.org/images/vigojug.jpg'
+groupLogo: '/images/groups/vigojug.jpg'
 title: 'Laretas AMA: Agustín Tourón'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=4WlTqDk0ASM'

--- a/src/content/videos/vigojug/4yvsszmhtzo.md
+++ b/src/content/videos/vigojug/4yvsszmhtzo.md
@@ -2,7 +2,7 @@
 sourceId: '4yvSSZMHTZo'
 groupId: 'vigojug'
 groupName: 'VigoJUG'
-groupLogo: 'https://vigotech.org/images/vigojug.jpg'
+groupLogo: '/images/groups/vigojug.jpg'
 title: 'Reactive programming con RxJava'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=4yvSSZMHTZo'

--- a/src/content/videos/vigojug/5braph5bypy.md
+++ b/src/content/videos/vigojug/5braph5bypy.md
@@ -2,7 +2,7 @@
 sourceId: '5BRaPH5BYPY'
 groupId: 'vigojug'
 groupName: 'VigoJUG'
-groupLogo: 'https://vigotech.org/images/vigojug.jpg'
+groupLogo: '/images/groups/vigojug.jpg'
 title: 'Laretas Geek - Octubre 2020 - Especial desarrollo web con Adalab'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=5BRaPH5BYPY'

--- a/src/content/videos/vigojug/7aiu-wlhlgk.md
+++ b/src/content/videos/vigojug/7aiu-wlhlgk.md
@@ -2,7 +2,7 @@
 sourceId: '7AiU-Wlhlgk'
 groupId: 'vigojug'
 groupName: 'VigoJUG'
-groupLogo: 'https://vigotech.org/images/vigojug.jpg'
+groupLogo: '/images/groups/vigojug.jpg'
 title: 'Laretas AMA: Fran Puga'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=7AiU-Wlhlgk'

--- a/src/content/videos/vigojug/7q-t-tbupcs.md
+++ b/src/content/videos/vigojug/7q-t-tbupcs.md
@@ -2,7 +2,7 @@
 sourceId: '7Q-t_TbUPCs'
 groupId: 'vigojug'
 groupName: 'VigoJUG'
-groupLogo: 'https://vigotech.org/images/vigojug.jpg'
+groupLogo: '/images/groups/vigojug.jpg'
 title: 'Laretas Geek - Marzo 2021 - especial Extreme Programming'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=7Q-t_TbUPCs'

--- a/src/content/videos/vigojug/8643werug-s.md
+++ b/src/content/videos/vigojug/8643werug-s.md
@@ -2,7 +2,7 @@
 sourceId: '8643WerUG-s'
 groupId: 'vigojug'
 groupName: 'VigoJUG'
-groupLogo: 'https://vigotech.org/images/vigojug.jpg'
+groupLogo: '/images/groups/vigojug.jpg'
 title: 'O cuarto meetup do VigoJUG: Kotlin, o Java para o século XXI'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=8643WerUG-s'

--- a/src/content/videos/vigojug/9-zms-8-01a.md
+++ b/src/content/videos/vigojug/9-zms-8-01a.md
@@ -2,7 +2,7 @@
 sourceId: '9_zMs-8-01A'
 groupId: 'vigojug'
 groupName: 'VigoJUG'
-groupLogo: 'https://vigotech.org/images/vigojug.jpg'
+groupLogo: '/images/groups/vigojug.jpg'
 title: 'Laretas AMA: André Maneiro'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=9_zMs-8-01A'

--- a/src/content/videos/vigojug/ajkifnwjug0.md
+++ b/src/content/videos/vigojug/ajkifnwjug0.md
@@ -2,7 +2,7 @@
 sourceId: 'aJkifnWjug0'
 groupId: 'vigojug'
 groupName: 'VigoJUG'
-groupLogo: 'https://vigotech.org/images/vigojug.jpg'
+groupLogo: '/images/groups/vigojug.jpg'
 title: 'Laretas AMA: Alberto Ruibal'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=aJkifnWjug0'

--- a/src/content/videos/vigojug/d-k35eeivca.md
+++ b/src/content/videos/vigojug/d-k35eeivca.md
@@ -2,7 +2,7 @@
 sourceId: 'd-K35EeIvcA'
 groupId: 'vigojug'
 groupName: 'VigoJUG'
-groupLogo: 'https://vigotech.org/images/vigojug.jpg'
+groupLogo: '/images/groups/vigojug.jpg'
 title: 'Laretas Geek - Enero 2021 - Especial Elastic'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=d-K35EeIvcA'

--- a/src/content/videos/vigojug/ftsdoh5g2nm.md
+++ b/src/content/videos/vigojug/ftsdoh5g2nm.md
@@ -2,7 +2,7 @@
 sourceId: 'FTsDoh5G2nM'
 groupId: 'vigojug'
 groupName: 'VigoJUG'
-groupLogo: 'https://vigotech.org/images/vigojug.jpg'
+groupLogo: '/images/groups/vigojug.jpg'
 title: 'JReleaser - Liberando a la velocidad de la luz'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=FTsDoh5G2nM'

--- a/src/content/videos/vigojug/fx1fzzphavu.md
+++ b/src/content/videos/vigojug/fx1fzzphavu.md
@@ -2,7 +2,7 @@
 sourceId: 'fX1fzZPHaVU'
 groupId: 'vigojug'
 groupName: 'VigoJUG'
-groupLogo: 'https://vigotech.org/images/vigojug.jpg'
+groupLogo: '/images/groups/vigojug.jpg'
 title: 'O sexto meetup do VigoJUG: "In-Memory Datagrid en arquitecturas de tiempo real"'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=fX1fzZPHaVU'

--- a/src/content/videos/vigojug/gqrj-vh7mr8.md
+++ b/src/content/videos/vigojug/gqrj-vh7mr8.md
@@ -2,7 +2,7 @@
 sourceId: 'gqrj-VH7mR8'
 groupId: 'vigojug'
 groupName: 'VigoJUG'
-groupLogo: 'https://vigotech.org/images/vigojug.jpg'
+groupLogo: '/images/groups/vigojug.jpg'
 title: 'Laretas AMA: Fernando Prieto'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=gqrj-VH7mR8'

--- a/src/content/videos/vigojug/jl7pegkda4s.md
+++ b/src/content/videos/vigojug/jl7pegkda4s.md
@@ -2,7 +2,7 @@
 sourceId: 'JL7pEGKda4s'
 groupId: 'vigojug'
 groupName: 'VigoJUG'
-groupLogo: 'https://vigotech.org/images/vigojug.jpg'
+groupLogo: '/images/groups/vigojug.jpg'
 title: 'Laretas AMA: Abdón Rodríguez'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=JL7pEGKda4s'

--- a/src/content/videos/vigojug/jokts-f4pts.md
+++ b/src/content/videos/vigojug/jokts-f4pts.md
@@ -2,7 +2,7 @@
 sourceId: 'JoKTs_F4PTs'
 groupId: 'vigojug'
 groupName: 'VigoJUG'
-groupLogo: 'https://vigotech.org/images/vigojug.jpg'
+groupLogo: '/images/groups/vigojug.jpg'
 title: 'LaretasGeek - Marzo 2021 - Especial Java 16'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=JoKTs_F4PTs'

--- a/src/content/videos/vigojug/jvfig1ukawc.md
+++ b/src/content/videos/vigojug/jvfig1ukawc.md
@@ -2,7 +2,7 @@
 sourceId: 'jvFiG1ukAWc'
 groupId: 'vigojug'
 groupName: 'VigoJUG'
-groupLogo: 'https://vigotech.org/images/vigojug.jpg'
+groupLogo: '/images/groups/vigojug.jpg'
 title: 'Laretas AMA: Antón Román'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=jvFiG1ukAWc'

--- a/src/content/videos/vigojug/k6s9w8iton0.md
+++ b/src/content/videos/vigojug/k6s9w8iton0.md
@@ -2,7 +2,7 @@
 sourceId: 'K6S9w8iton0'
 groupId: 'vigojug'
 groupName: 'VigoJUG'
-groupLogo: 'https://vigotech.org/images/vigojug.jpg'
+groupLogo: '/images/groups/vigojug.jpg'
 title: 'Laretas AMA: Pilar Vila'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=K6S9w8iton0'

--- a/src/content/videos/vigojug/khdve9foa-u.md
+++ b/src/content/videos/vigojug/khdve9foa-u.md
@@ -2,7 +2,7 @@
 sourceId: 'KHdVe9fOa-U'
 groupId: 'vigojug'
 groupName: 'VigoJUG'
-groupLogo: 'https://vigotech.org/images/vigojug.jpg'
+groupLogo: '/images/groups/vigojug.jpg'
 title: 'Introducción de Cassandra con Java'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=KHdVe9fOa-U'

--- a/src/content/videos/vigojug/km9yicqhtps.md
+++ b/src/content/videos/vigojug/km9yicqhtps.md
@@ -2,7 +2,7 @@
 sourceId: 'km9YiCqhtps'
 groupId: 'vigojug'
 groupName: 'VigoJUG'
-groupLogo: 'https://vigotech.org/images/vigojug.jpg'
+groupLogo: '/images/groups/vigojug.jpg'
 title: 'Laretas AMA: Eloy Coto'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=km9YiCqhtps'

--- a/src/content/videos/vigojug/l25ryirmtyq.md
+++ b/src/content/videos/vigojug/l25ryirmtyq.md
@@ -2,7 +2,7 @@
 sourceId: 'L25ryiRmTYQ'
 groupId: 'vigojug'
 groupName: 'VigoJUG'
-groupLogo: 'https://vigotech.org/images/vigojug.jpg'
+groupLogo: '/images/groups/vigojug.jpg'
 title: 'Laretas Geek - Septiembre 2020 - Especial Apache Kafka'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=L25ryiRmTYQ'

--- a/src/content/videos/vigojug/mewdxxkjgsy.md
+++ b/src/content/videos/vigojug/mewdxxkjgsy.md
@@ -2,7 +2,7 @@
 sourceId: 'MewdxXkjgsY'
 groupId: 'vigojug'
 groupName: 'VigoJUG'
-groupLogo: 'https://vigotech.org/images/vigojug.jpg'
+groupLogo: '/images/groups/vigojug.jpg'
 title: 'Laretas Geek - Diciembre 2020 - Especial Java Champions'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=MewdxXkjgsY'

--- a/src/content/videos/vigojug/mtcimjbfej0.md
+++ b/src/content/videos/vigojug/mtcimjbfej0.md
@@ -2,7 +2,7 @@
 sourceId: 'MtcImjBFEj0'
 groupId: 'vigojug'
 groupName: 'VigoJUG'
-groupLogo: 'https://vigotech.org/images/vigojug.jpg'
+groupLogo: '/images/groups/vigojug.jpg'
 title: 'Laretas Geek - Junio 2020 - Mesa redonda 25 años de Java'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=MtcImjBFEj0'

--- a/src/content/videos/vigojug/nvhjthobq5i.md
+++ b/src/content/videos/vigojug/nvhjthobq5i.md
@@ -2,7 +2,7 @@
 sourceId: 'nvHJthOBQ5I'
 groupId: 'vigojug'
 groupName: 'VigoJUG'
-groupLogo: 'https://vigotech.org/images/vigojug.jpg'
+groupLogo: '/images/groups/vigojug.jpg'
 title: 'LaretasGeek - Febrero 2021 - Especial Developer Experience'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=nvHJthOBQ5I'

--- a/src/content/videos/vigojug/pkqtlj38x7m.md
+++ b/src/content/videos/vigojug/pkqtlj38x7m.md
@@ -2,7 +2,7 @@
 sourceId: 'PKqTlj38X7M'
 groupId: 'vigojug'
 groupName: 'VigoJUG'
-groupLogo: 'https://vigotech.org/images/vigojug.jpg'
+groupLogo: '/images/groups/vigojug.jpg'
 title: 'Make Java Great Again! por @tomasalmeida de Netcentric. 30 min.'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=PKqTlj38X7M'

--- a/src/content/videos/vigojug/plsc3jnbx5o.md
+++ b/src/content/videos/vigojug/plsc3jnbx5o.md
@@ -2,7 +2,7 @@
 sourceId: 'pLsC3jnbX5o'
 groupId: 'vigojug'
 groupName: 'VigoJUG'
-groupLogo: 'https://vigotech.org/images/vigojug.jpg'
+groupLogo: '/images/groups/vigojug.jpg'
 title: 'Emisión en directo de Vigo JUG'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=pLsC3jnbX5o'

--- a/src/content/videos/vigojug/se0ov3v11mm.md
+++ b/src/content/videos/vigojug/se0ov3v11mm.md
@@ -2,7 +2,7 @@
 sourceId: 'Se0Ov3V11MM'
 groupId: 'vigojug'
 groupName: 'VigoJUG'
-groupLogo: 'https://vigotech.org/images/vigojug.jpg'
+groupLogo: '/images/groups/vigojug.jpg'
 title: 'O sétimo meetup do VigoJUG: Desarrollo de microservicios con Spring Boot'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=Se0Ov3V11MM'

--- a/src/content/videos/vigojug/shw-mdfmqfa.md
+++ b/src/content/videos/vigojug/shw-mdfmqfa.md
@@ -2,7 +2,7 @@
 sourceId: 'SHw_MdfmqfA'
 groupId: 'vigojug'
 groupName: 'VigoJUG'
-groupLogo: 'https://vigotech.org/images/vigojug.jpg'
+groupLogo: '/images/groups/vigojug.jpg'
 title: 'Laretas Geek - Agosto 2020 - Especial Comunidades Galicia'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=SHw_MdfmqfA'

--- a/src/content/videos/vigojug/smg2p6esvnc.md
+++ b/src/content/videos/vigojug/smg2p6esvnc.md
@@ -2,7 +2,7 @@
 sourceId: 'smG2P6Esvnc'
 groupId: 'vigojug'
 groupName: 'VigoJUG'
-groupLogo: 'https://vigotech.org/images/vigojug.jpg'
+groupLogo: '/images/groups/vigojug.jpg'
 title: '"De Groovy... e Sancho Panza" por Antón Rodríguez de Optare Solutions 30 min.'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=smG2P6Esvnc'

--- a/src/content/videos/vigojug/tx-ji5ftxpq.md
+++ b/src/content/videos/vigojug/tx-ji5ftxpq.md
@@ -2,7 +2,7 @@
 sourceId: 'tx_ji5FTXPQ'
 groupId: 'vigojug'
 groupName: 'VigoJUG'
-groupLogo: 'https://vigotech.org/images/vigojug.jpg'
+groupLogo: '/images/groups/vigojug.jpg'
 title: 'Laretas AMA: Luz Castro'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=tx_ji5FTXPQ'

--- a/src/content/videos/vigojug/vyo-e3a9hlg.md
+++ b/src/content/videos/vigojug/vyo-e3a9hlg.md
@@ -2,7 +2,7 @@
 sourceId: 'vYO-e3A9hlg'
 groupId: 'vigojug'
 groupName: 'VigoJUG'
-groupLogo: 'https://vigotech.org/images/vigojug.jpg'
+groupLogo: '/images/groups/vigojug.jpg'
 title: 'Laretas AMA: David García'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=vYO-e3A9hlg'

--- a/src/content/videos/vigojug/w-kkwegct0.md
+++ b/src/content/videos/vigojug/w-kkwegct0.md
@@ -2,7 +2,7 @@
 sourceId: '_w_kKWeGct0'
 groupId: 'vigojug'
 groupName: 'VigoJUG'
-groupLogo: 'https://vigotech.org/images/vigojug.jpg'
+groupLogo: '/images/groups/vigojug.jpg'
 title: 'Quarkus World Tour 2021: VigoJUG & CoruñaJUG'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=_w_kKWeGct0'

--- a/src/content/videos/vigojug/wheiaflsayw.md
+++ b/src/content/videos/vigojug/wheiaflsayw.md
@@ -2,7 +2,7 @@
 sourceId: 'WHeIAfLsAyw'
 groupId: 'vigojug'
 groupName: 'VigoJUG'
-groupLogo: 'https://vigotech.org/images/vigojug.jpg'
+groupLogo: '/images/groups/vigojug.jpg'
 title: 'Laretas AMA: Miguel Camba'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=WHeIAfLsAyw'

--- a/src/content/videos/vigojug/xe4q7ocbxy8.md
+++ b/src/content/videos/vigojug/xe4q7ocbxy8.md
@@ -2,7 +2,7 @@
 sourceId: 'XE4q7OCBXy8'
 groupId: 'vigojug'
 groupName: 'VigoJUG'
-groupLogo: 'https://vigotech.org/images/vigojug.jpg'
+groupLogo: '/images/groups/vigojug.jpg'
 title: 'Laretas AMA: Telmo Pérez'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=XE4q7OCBXy8'

--- a/src/content/videos/vigojug/xyztcy5wqnc.md
+++ b/src/content/videos/vigojug/xyztcy5wqnc.md
@@ -2,7 +2,7 @@
 sourceId: 'XyZTCy5WQNc'
 groupId: 'vigojug'
 groupName: 'VigoJUG'
-groupLogo: 'https://vigotech.org/images/vigojug.jpg'
+groupLogo: '/images/groups/vigojug.jpg'
 title: 'Laretas Geek - Julio 2020 - Especial Engineering Management'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=XyZTCy5WQNc'

--- a/src/content/videos/vigojug/z-4up8hzjlq.md
+++ b/src/content/videos/vigojug/z-4up8hzjlq.md
@@ -2,7 +2,7 @@
 sourceId: 'z_4Up8HzjLQ'
 groupId: 'vigojug'
 groupName: 'VigoJUG'
-groupLogo: 'https://vigotech.org/images/vigojug.jpg'
+groupLogo: '/images/groups/vigojug.jpg'
 title: 'Laretas Geek - Noviembre 2020 - Especial Kubernetes'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=z_4Up8HzjLQ'

--- a/src/content/videos/vigojug/z1namxsblmi.md
+++ b/src/content/videos/vigojug/z1namxsblmi.md
@@ -2,7 +2,7 @@
 sourceId: 'Z1NAmxSbLMI'
 groupId: 'vigojug'
 groupName: 'VigoJUG'
-groupLogo: 'https://vigotech.org/images/vigojug.jpg'
+groupLogo: '/images/groups/vigojug.jpg'
 title: 'Laretas Geek - Mayo 2021 - Especial SpringBoot'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=Z1NAmxSbLMI'

--- a/src/content/videos/vigowordpress/0sjwsqqywq8.md
+++ b/src/content/videos/vigowordpress/0sjwsqqywq8.md
@@ -2,7 +2,7 @@
 sourceId: '0SjwSQqYWQ8'
 groupId: 'vigowordpress'
 groupName: 'VigoWordpress'
-groupLogo: 'https://vigotech.org/images/vigowordpress.png'
+groupLogo: '/images/groups/vigowordpress.png'
 title: 'Meetup #02 - Jerarquía de plantillas, el ABC para desarrollar con WordPress'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=0SjwSQqYWQ8'

--- a/src/content/videos/vigowordpress/34nkuicspsm.md
+++ b/src/content/videos/vigowordpress/34nkuicspsm.md
@@ -2,7 +2,7 @@
 sourceId: '34NKuIcSPSM'
 groupId: 'vigowordpress'
 groupName: 'VigoWordpress'
-groupLogo: 'https://vigotech.org/images/vigowordpress.png'
+groupLogo: '/images/groups/vigowordpress.png'
 title: 'El bienestar corporativo y como multiplicar los resultados de la empresa'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=34NKuIcSPSM'

--- a/src/content/videos/vigowordpress/axgsnbt9a3m.md
+++ b/src/content/videos/vigowordpress/axgsnbt9a3m.md
@@ -2,7 +2,7 @@
 sourceId: 'AXgsnBT9A3M'
 groupId: 'vigowordpress'
 groupName: 'VigoWordpress'
-groupLogo: 'https://vigotech.org/images/vigowordpress.png'
+groupLogo: '/images/groups/vigowordpress.png'
 title: 'Ilustración, cómic y marca identidad ilustrada'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=AXgsnBT9A3M'

--- a/src/content/videos/vigowordpress/bqhakj6y7-q.md
+++ b/src/content/videos/vigowordpress/bqhakj6y7-q.md
@@ -2,7 +2,7 @@
 sourceId: 'bQhakj6y7-Q'
 groupId: 'vigowordpress'
 groupName: 'VigoWordpress'
-groupLogo: 'https://vigotech.org/images/vigowordpress.png'
+groupLogo: '/images/groups/vigowordpress.png'
 title: 'Factura electrónica vs Verifactu:  Diferencias, obligaciones y soluciones'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=bQhakj6y7-Q'

--- a/src/content/videos/vigowordpress/cpgi6sqmbnw.md
+++ b/src/content/videos/vigowordpress/cpgi6sqmbnw.md
@@ -2,7 +2,7 @@
 sourceId: 'cpGi6sQMbnw'
 groupId: 'vigowordpress'
 groupName: 'VigoWordpress'
-groupLogo: 'https://vigotech.org/images/vigowordpress.png'
+groupLogo: '/images/groups/vigowordpress.png'
 title: 'MeetUp WordPress Vigo 24 10 2023'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=cpGi6sQMbnw'

--- a/src/content/videos/vigowordpress/cqamk4jm5y0.md
+++ b/src/content/videos/vigowordpress/cqamk4jm5y0.md
@@ -2,7 +2,7 @@
 sourceId: 'cQaMK4jm5Y0'
 groupId: 'vigowordpress'
 groupName: 'VigoWordpress'
-groupLogo: 'https://vigotech.org/images/vigowordpress.png'
+groupLogo: '/images/groups/vigowordpress.png'
 title: 'Los ingredientes de una buena estrategia de DATA DRIVEN en las campañas de publicidad'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=cQaMK4jm5Y0'

--- a/src/content/videos/vigowordpress/djlp6vgnttu.md
+++ b/src/content/videos/vigowordpress/djlp6vgnttu.md
@@ -2,7 +2,7 @@
 sourceId: 'DjLP6VgNtTU'
 groupId: 'vigowordpress'
 groupName: 'VigoWordpress'
-groupLogo: 'https://vigotech.org/images/vigowordpress.png'
+groupLogo: '/images/groups/vigowordpress.png'
 title: 'Meetup #12 - WooCommerce no es solo una tienda online'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=DjLP6VgNtTU'

--- a/src/content/videos/vigowordpress/dujalqnvve8.md
+++ b/src/content/videos/vigowordpress/dujalqnvve8.md
@@ -2,7 +2,7 @@
 sourceId: 'DuJaLqNVVe8'
 groupId: 'vigowordpress'
 groupName: 'VigoWordpress'
-groupLogo: 'https://vigotech.org/images/vigowordpress.png'
+groupLogo: '/images/groups/vigowordpress.png'
 title: 'Meetup #03 - RRSS y su importancia en los negocios digitales'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=DuJaLqNVVe8'

--- a/src/content/videos/vigowordpress/evo7vic0b80.md
+++ b/src/content/videos/vigowordpress/evo7vic0b80.md
@@ -2,7 +2,7 @@
 sourceId: 'EVo7vic0b80'
 groupId: 'vigowordpress'
 groupName: 'VigoWordpress'
-groupLogo: 'https://vigotech.org/images/vigowordpress.png'
+groupLogo: '/images/groups/vigowordpress.png'
 title: 'Meetup #07 - ¿Y después qué?'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=EVo7vic0b80'

--- a/src/content/videos/vigowordpress/gbqce-yn7bi.md
+++ b/src/content/videos/vigowordpress/gbqce-yn7bi.md
@@ -2,7 +2,7 @@
 sourceId: 'GbqcE-YN7BI'
 groupId: 'vigowordpress'
 groupName: 'VigoWordpress'
-groupLogo: 'https://vigotech.org/images/vigowordpress.png'
+groupLogo: '/images/groups/vigowordpress.png'
 title: 'Creando asistentes virtuales con Inteligencia Artificial'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=GbqcE-YN7BI'

--- a/src/content/videos/vigowordpress/ic-typrnn6u.md
+++ b/src/content/videos/vigowordpress/ic-typrnn6u.md
@@ -2,7 +2,7 @@
 sourceId: 'iC-typrnn6U'
 groupId: 'vigowordpress'
 groupName: 'VigoWordpress'
-groupLogo: 'https://vigotech.org/images/vigowordpress.png'
+groupLogo: '/images/groups/vigowordpress.png'
 title: 'Meetup #06 - Dominios y hostings: el interrogatorio'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=iC-typrnn6U'

--- a/src/content/videos/vigowordpress/il-zcyigfuo.md
+++ b/src/content/videos/vigowordpress/il-zcyigfuo.md
@@ -2,7 +2,7 @@
 sourceId: 'il_ZCYIgFUo'
 groupId: 'vigowordpress'
 groupName: 'VigoWordpress'
-groupLogo: 'https://vigotech.org/images/vigowordpress.png'
+groupLogo: '/images/groups/vigowordpress.png'
 title: 'Manteniendo la tradición en un eCommerce: Cómo Peperetes preserva lo artesanal'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=il_ZCYIgFUo'

--- a/src/content/videos/vigowordpress/iwd72h69xqo.md
+++ b/src/content/videos/vigowordpress/iwd72h69xqo.md
@@ -2,7 +2,7 @@
 sourceId: 'IWd72H69Xqo'
 groupId: 'vigowordpress'
 groupName: 'VigoWordpress'
-groupLogo: 'https://vigotech.org/images/vigowordpress.png'
+groupLogo: '/images/groups/vigowordpress.png'
 title: 'Convertir emoción en experiencias digitales'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=IWd72H69Xqo'

--- a/src/content/videos/vigowordpress/kfljqsvzkec.md
+++ b/src/content/videos/vigowordpress/kfljqsvzkec.md
@@ -2,7 +2,7 @@
 sourceId: 'kFLjqsvZKEc'
 groupId: 'vigowordpress'
 groupName: 'VigoWordpress'
-groupLogo: 'https://vigotech.org/images/vigowordpress.png'
+groupLogo: '/images/groups/vigowordpress.png'
 title: 'Posicionando sin IA en tiempos de IA'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=kFLjqsvZKEc'

--- a/src/content/videos/vigowordpress/kl6cev339mo.md
+++ b/src/content/videos/vigowordpress/kl6cev339mo.md
@@ -2,7 +2,7 @@
 sourceId: 'KL6cev339Mo'
 groupId: 'vigowordpress'
 groupName: 'VigoWordpress'
-groupLogo: 'https://vigotech.org/images/vigowordpress.png'
+groupLogo: '/images/groups/vigowordpress.png'
 title: 'Meetup #05 - Cómo ser un profesional freelance legal'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=KL6cev339Mo'

--- a/src/content/videos/vigowordpress/kpsqflq9dpq.md
+++ b/src/content/videos/vigowordpress/kpsqflq9dpq.md
@@ -2,7 +2,7 @@
 sourceId: 'kPsqFlq9DPQ'
 groupId: 'vigowordpress'
 groupName: 'VigoWordpress'
-groupLogo: 'https://vigotech.org/images/vigowordpress.png'
+groupLogo: '/images/groups/vigowordpress.png'
 title: 'Meetup #09 - Modelo de negocio de un profesional freelance'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=kPsqFlq9DPQ'

--- a/src/content/videos/vigowordpress/kstyiqqofae.md
+++ b/src/content/videos/vigowordpress/kstyiqqofae.md
@@ -2,7 +2,7 @@
 sourceId: 'kstyIQqofaE'
 groupId: 'vigowordpress'
 groupName: 'VigoWordpress'
-groupLogo: 'https://vigotech.org/images/vigowordpress.png'
+groupLogo: '/images/groups/vigowordpress.png'
 title: 'Meetup #17 - ¿Tienes un ecommerce y no consigues vender lo que esperabas?'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=kstyIQqofaE'

--- a/src/content/videos/vigowordpress/l6asdje-2vc.md
+++ b/src/content/videos/vigowordpress/l6asdje-2vc.md
@@ -2,7 +2,7 @@
 sourceId: 'L6aSDjE_2Vc'
 groupId: 'vigowordpress'
 groupName: 'VigoWordpress'
-groupLogo: 'https://vigotech.org/images/vigowordpress.png'
+groupLogo: '/images/groups/vigowordpress.png'
 title: 'Meetup #11 - Cómo gestionar una gran cantidad de sitios WordPress'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=L6aSDjE_2Vc'

--- a/src/content/videos/vigowordpress/llac-qs9fj8.md
+++ b/src/content/videos/vigowordpress/llac-qs9fj8.md
@@ -2,7 +2,7 @@
 sourceId: 'lLac-qS9fj8'
 groupId: 'vigowordpress'
 groupName: 'VigoWordpress'
-groupLogo: 'https://vigotech.org/images/vigowordpress.png'
+groupLogo: '/images/groups/vigowordpress.png'
 title: 'Meetup #01 - Plugins recomendados para WordPress y cómo crear el tuyo'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=lLac-qS9fj8'

--- a/src/content/videos/vigowordpress/lu3cuxdgegw.md
+++ b/src/content/videos/vigowordpress/lu3cuxdgegw.md
@@ -2,7 +2,7 @@
 sourceId: 'Lu3Cuxdgegw'
 groupId: 'vigowordpress'
 groupName: 'VigoWordpress'
-groupLogo: 'https://vigotech.org/images/vigowordpress.png'
+groupLogo: '/images/groups/vigowordpress.png'
 title: 'Aspectos legales del desarrollo de software'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=Lu3Cuxdgegw'

--- a/src/content/videos/vigowordpress/o-z-8jx5eok.md
+++ b/src/content/videos/vigowordpress/o-z-8jx5eok.md
@@ -2,7 +2,7 @@
 sourceId: 'O-z_8jx5EOk'
 groupId: 'vigowordpress'
 groupName: 'VigoWordpress'
-groupLogo: 'https://vigotech.org/images/vigowordpress.png'
+groupLogo: '/images/groups/vigowordpress.png'
 title: 'Cómo construir una marca sólida y generar ventas a través del contenido gratuito'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=O-z_8jx5EOk'

--- a/src/content/videos/vigowordpress/oq-hsvww4hi.md
+++ b/src/content/videos/vigowordpress/oq-hsvww4hi.md
@@ -2,7 +2,7 @@
 sourceId: 'oQ-hSvWw4HI'
 groupId: 'vigowordpress'
 groupName: 'VigoWordpress'
-groupLogo: 'https://vigotech.org/images/vigowordpress.png'
+groupLogo: '/images/groups/vigowordpress.png'
 title: 'Meetup #08 - WordPress: Campamento base de tu Marca Personal'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=oQ-hSvWw4HI'

--- a/src/content/videos/vigowordpress/oxqql7jxcgi.md
+++ b/src/content/videos/vigowordpress/oxqql7jxcgi.md
@@ -2,7 +2,7 @@
 sourceId: 'OXqQL7jXCGI'
 groupId: 'vigowordpress'
 groupName: 'VigoWordpress'
-groupLogo: 'https://vigotech.org/images/vigowordpress.png'
+groupLogo: '/images/groups/vigowordpress.png'
 title: 'Green Web  diseños web eficientes, optimizados y de transferencia de datos reducida'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=OXqQL7jXCGI'

--- a/src/content/videos/vigowordpress/p4qkypydt3s.md
+++ b/src/content/videos/vigowordpress/p4qkypydt3s.md
@@ -2,7 +2,7 @@
 sourceId: 'p4qKYpYDT3s'
 groupId: 'vigowordpress'
 groupName: 'VigoWordpress'
-groupLogo: 'https://vigotech.org/images/vigowordpress.png'
+groupLogo: '/images/groups/vigowordpress.png'
 title: 'Internacionalización de empresas:  La era de la exportación digital'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=p4qKYpYDT3s'

--- a/src/content/videos/vigowordpress/quj83yrodhs.md
+++ b/src/content/videos/vigowordpress/quj83yrodhs.md
@@ -2,7 +2,7 @@
 sourceId: 'quj83YRodhs'
 groupId: 'vigowordpress'
 groupName: 'VigoWordpress'
-groupLogo: 'https://vigotech.org/images/vigowordpress.png'
+groupLogo: '/images/groups/vigowordpress.png'
 title: 'SEO Local: Cómo ser uno de los tres elegidos de Google'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=quj83YRodhs'

--- a/src/content/videos/vigowordpress/rtnoqecgakc.md
+++ b/src/content/videos/vigowordpress/rtnoqecgakc.md
@@ -2,7 +2,7 @@
 sourceId: 'RtnOqeCGAKc'
 groupId: 'vigowordpress'
 groupName: 'VigoWordpress'
-groupLogo: 'https://vigotech.org/images/vigowordpress.png'
+groupLogo: '/images/groups/vigowordpress.png'
 title: 'Meetup #13 - Bailaré sobre tu SEO: Google, WordPress y otras historias del punk'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=RtnOqeCGAKc'

--- a/src/content/videos/vigowordpress/t8ecwcrslsa.md
+++ b/src/content/videos/vigowordpress/t8ecwcrslsa.md
@@ -2,7 +2,7 @@
 sourceId: 't8ECwCRSlsA'
 groupId: 'vigowordpress'
 groupName: 'VigoWordpress'
-groupLogo: 'https://vigotech.org/images/vigowordpress.png'
+groupLogo: '/images/groups/vigowordpress.png'
 title: 'Meetup #14 - Encuentra y lanza tu idea de negocio'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=t8ECwCRSlsA'

--- a/src/content/videos/vigowordpress/umjgn-gtid0.md
+++ b/src/content/videos/vigowordpress/umjgn-gtid0.md
@@ -2,7 +2,7 @@
 sourceId: 'uMJGN-gTid0'
 groupId: 'vigowordpress'
 groupName: 'VigoWordpress'
-groupLogo: 'https://vigotech.org/images/vigowordpress.png'
+groupLogo: '/images/groups/vigowordpress.png'
 title: 'Meetup #04 - CoP: Comunidades de práctica online'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=uMJGN-gTid0'

--- a/src/content/videos/vigowordpress/wjvxjbgmk9a.md
+++ b/src/content/videos/vigowordpress/wjvxjbgmk9a.md
@@ -2,7 +2,7 @@
 sourceId: 'wJvxjbGmK9A'
 groupId: 'vigowordpress'
 groupName: 'VigoWordpress'
-groupLogo: 'https://vigotech.org/images/vigowordpress.png'
+groupLogo: '/images/groups/vigowordpress.png'
 title: 'Meetup #10 - ¿Cuánto cuesta una web? Y, ¿como poner en valor mi trabajo?'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=wJvxjbGmK9A'

--- a/src/content/videos/vigowordpress/wn3dyenpw4m.md
+++ b/src/content/videos/vigowordpress/wn3dyenpw4m.md
@@ -2,7 +2,7 @@
 sourceId: 'WN3dyEnpW4M'
 groupId: 'vigowordpress'
 groupName: 'VigoWordpress'
-groupLogo: 'https://vigotech.org/images/vigowordpress.png'
+groupLogo: '/images/groups/vigowordpress.png'
 title: 'Meetup #16 - WebP, un formato para dominarlos a todos'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=WN3dyEnpW4M'

--- a/src/content/videos/vigowordpress/x-j-xwr3dwc.md
+++ b/src/content/videos/vigowordpress/x-j-xwr3dwc.md
@@ -2,7 +2,7 @@
 sourceId: 'x_J_XWR3dwc'
 groupId: 'vigowordpress'
 groupName: 'VigoWordpress'
-groupLogo: 'https://vigotech.org/images/vigowordpress.png'
+groupLogo: '/images/groups/vigowordpress.png'
 title: 'No dejes la puerta abierta   ciberseguridad para WordPress'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=x_J_XWR3dwc'

--- a/src/content/videos/vigowordpress/yhyx0ao6zci.md
+++ b/src/content/videos/vigowordpress/yhyx0ao6zci.md
@@ -2,7 +2,7 @@
 sourceId: 'YHyx0ao6zCI'
 groupId: 'vigowordpress'
 groupName: 'VigoWordpress'
-groupLogo: 'https://vigotech.org/images/vigowordpress.png'
+groupLogo: '/images/groups/vigowordpress.png'
 title: 'Impacto y experiencia del do_action WCVIGO2024'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=YHyx0ao6zCI'

--- a/src/content/videos/vigowordpress/yx79lpgolku.md
+++ b/src/content/videos/vigowordpress/yx79lpgolku.md
@@ -2,7 +2,7 @@
 sourceId: 'yX79lPGolKU'
 groupId: 'vigowordpress'
 groupName: 'VigoWordpress'
-groupLogo: 'https://vigotech.org/images/vigowordpress.png'
+groupLogo: '/images/groups/vigowordpress.png'
 title: 'IA generativa y marketing real: cómo ahorrar tiempo, vender más y fidelizar mejor'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=yX79lPGolKU'

--- a/src/content/videos/vigowordpress/z7uyexby9ra.md
+++ b/src/content/videos/vigowordpress/z7uyexby9ra.md
@@ -2,7 +2,7 @@
 sourceId: 'Z7uyExBY9rA'
 groupId: 'vigowordpress'
 groupName: 'VigoWordpress'
-groupLogo: 'https://vigotech.org/images/vigowordpress.png'
+groupLogo: '/images/groups/vigowordpress.png'
 title: 'Haz que te encuentren cómo destacar tu perfil profesional y atraer oportunidades'
 player: 'youtube'
 url: 'https://www.youtube.com/watch?v=Z7uyExBY9rA'

--- a/src/lib/vigotech/selectors.ts
+++ b/src/lib/vigotech/selectors.ts
@@ -49,7 +49,8 @@ export const getTopGroupsByLastEvent = (
     }
   }
 
-  return [...groups]
+  return groups
+    .filter((group) => !group.data.inactive)
     .sort((a, b) => {
       const aDate = lastEventByGroup.get(a.id) ?? 0
       const bDate = lastEventByGroup.get(b.id) ?? 0

--- a/src/lib/vigotech/source.ts
+++ b/src/lib/vigotech/source.ts
@@ -73,6 +73,11 @@ export const toLocalGroupLogo = (logo: string | null | undefined): string | null
     return logo
   }
 
+  const fromGroupsUrl = logo.match(/\/images\/groups\/([^/?#]+)$/i)?.[1]
+  if (fromGroupsUrl) {
+    return `/images/groups/${fromGroupsUrl}`
+  }
+
   const fromUrl = logo.match(/\/images\/([^/?#]+)$/i)?.[1]
   if (fromUrl) {
     return `/images/groups/${fromUrl}`

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -29,6 +29,7 @@
 @theme {
   --color-primary: var(--accent);
   --color-primary-strong: var(--accent-strong);
+  --color-primary-past: var(--accent-past);
   --color-surface: var(--bg);
   --color-surface-panel: var(--bg-panel);
   --color-ink: var(--ink);
@@ -55,6 +56,7 @@
   --line: #d9e4e9;
   --accent: #e84a5f;
   --accent-strong: #d33b51;
+  --accent-past: color-mix(in srgb, var(--accent-strong) 55%, black);
 
   --shell-width: 1200px;
 }
@@ -70,6 +72,7 @@
   --line: #2a3b4d;
   --accent: #e84a5f;
   --accent-strong: #ff3559;
+  --accent-past: color-mix(in srgb, var(--accent-strong) 62%, black);
 }
 
 html,


### PR DESCRIPTION
## Summary
This PR focuses on fixing broken group logo rendering and cleaning up generated event data so duplicated or stale event entries no longer appear.
It also includes the related branch updates already present around Meetup event identity handling, generated content refreshes, and GitHub Actions workflow modernization.

## Changes
### Fixes
- Update VigoTech-hosted group logo URLs to the new `/images/groups/...` path convention
- Ensure logo normalization handles both legacy `/images/...` URLs and the new `/images/groups/...` URLs
- Keep group logo avatars square and contained so logos remain visible instead of being cropped or distorted
- Fix duplicated generated events by deduping stable event identities and pruning stale generated markdown files
- Restore missing Meetup-backed event entries after the `metagroup-schema-tools` source ID update

### Chores
- Refresh generated event and video content after the event identity and logo-path changes
- Keep the branch’s GitHub Actions upgrades and pnpm cache setup fixes already included here

## PR Details (AI generated)

### Goals
This PR fixes two user-visible issues on the site. First, some community logos, especially VigoWordPress in event cards, were not rendering correctly because the project was still carrying a mix of legacy logo URLs and newer local asset paths. Second, generated event content had started to accumulate duplicate or stale entries after upstream event identifiers changed, which caused duplicated event cards and inconsistent generated markdown files.

### Changes in detail

#### Fixes
- Updated `public/vigotech.json` so VigoTech-hosted group logos now point to the new `https://vigotech.org/images/groups/...` path layout
- Extended `toLocalGroupLogo(...)` in both the runtime source helper and the generator so it understands legacy URLs, new group URLs, and already-local `/images/groups/...` paths
- Updated `GroupLogo.astro` so it normalizes incoming logo paths before rendering and keeps the avatar frame square with contained imagery
- Improved generated-event deduplication in `scripts/generate-vigotech-json.mjs` so events are merged by stable identity using link first and normalized title plus date as fallback
- Added cleanup for stale generated markdown files so old event files are removed when canonical generated identifiers change
- Refreshed generated event data so duplicated A Industriosa and VigoWordPress event entries are removed from the generated output

#### Chores
- Includes the already-present branch updates around `metagroup-schema-tools@1.1.1`, generated content refreshes, and workflow action upgrades
- Keeps the Pages workflow updates to newer action versions and the pnpm setup ordering fix on the same branch

### Notes
This branch already contains several related fixes that were built incrementally, so the cleanest review path is to focus on the latest user-visible outcomes: logo rendering, square/contained avatars, and duplicate event cleanup. Generated content changes are expected because the fixes affect both logo source paths and event identity handling.