### PR TITLE
feat: mark Cloud Native Galicia as active

### DIFF
--- a/public/vigotech.json
+++ b/public/vigotech.json
@@ -72,8 +72,7 @@
         "twitter": "https://x.com/cloudnativegal",
         "linkedin": "https://www.linkedin.com/company/104357067",
         "cncf": "https://community.cncf.io/cloud-native-galicia/"
-      },
-      "inactive": true
+      }
     },
     "craftersvigo": {
       "name": "Crafters Vigo",


### PR DESCRIPTION
Remove inactive flag so the community appears in the active communities section of the VigoTech Alliance website.